### PR TITLE
Fix Interface mapping

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes a bug where an Interface is not properly registered, resulting in an infinite-loop for mapping Interfaces to polymorphic Models.

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -683,11 +683,13 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
 
             if make_interface:
                 mapped_type = strawberry.interface(type_)
+                self.mapped_interfaces[type_.__name__] = mapped_type
             elif use_federation:
                 mapped_type = strawberry.federation.type(type_)
+                self.mapped_types[type_.__name__] = mapped_type
             else:
                 mapped_type = strawberry.type(type_)
-            self.mapped_types[type_.__name__] = mapped_type
+                self.mapped_types[type_.__name__] = mapped_type
             setattr(mapped_type, _GENERATED_FIELD_KEYS_KEY, generated_field_keys)
             setattr(mapped_type, _ORIGINAL_TYPE_KEY, type_)
             return mapped_type
@@ -728,7 +730,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
             self.edge_types.values(),
             self.connection_types.values(),
         ):
-            for field in mapped_type._type_definition.fields:
+            for field in mapped_type.__strawberry_definition__.fields:
                 if field.name in getattr(mapped_type, _GENERATED_FIELD_KEYS_KEY):
                     namespace = {}
                     if hasattr(mapped_type, _ORIGINAL_TYPE_KEY):


### PR DESCRIPTION
## Description

Fixes a bug where an Interface is not properly registered, resulting in an infinite-loop for mapping Interfaces to polymorphic Models.

Changes:
- Properly adds Interfaces to `mapped_interfaces`
- Updates deprecated `_type_definition` references to `__strawberry_definition__ `

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
