### PR TITLE
chore: Group Dependabot Updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    all-dependencies:
+      patterns:
+        - "*"
   allow:
   - dependency-type: direct
   ignore:


### PR DESCRIPTION
@mattalbr @patrick91 Please lmk what you think of this. I personally prefer 1 big dependabot PR over the current opening and closing spam I have in my notifications. 