### PR TITLE
refactor!: map BigInteger to new BigInt scalar

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Natively supports the following SQLAlchemy types:
 ```python
 Integer: int,
 Float: float,
-BigInteger: Int64,
+BigInteger: BigInt,
 Numeric: Decimal,
 DateTime: datetime,
 Date: date,

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Natively supports the following SQLAlchemy types:
 ```python
 Integer: int,
 Float: float,
-BigInteger: int,
+BigInteger: Int64,
 Numeric: Decimal,
 DateTime: datetime,
 Date: date,

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-This change implements a new custom scalar `Int64` that is mapped to SQLAlchemy's `BigInteger`.
+This change implements a new custom scalar `BigInt` that is mapped to SQLAlchemy's `BigInteger`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+This change implements a new custom scalar `Int64` that is mapped to SQLAlchemy's `BigInteger`.

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -92,7 +92,7 @@ from strawberry_sqlalchemy_mapper.relay import (
     resolve_model_node,
     resolve_model_nodes,
 )
-from strawberry_sqlalchemy_mapper.scalars import Int64
+from strawberry_sqlalchemy_mapper.scalars import BigInt
 
 if TYPE_CHECKING:
     from sqlalchemy.sql.expression import ColumnElement
@@ -180,7 +180,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
     ] = {
         Integer: int,
         Float: float,
-        BigInteger: Int64,
+        BigInteger: BigInt,
         Numeric: Decimal,
         DateTime: datetime,
         Date: date,
@@ -339,7 +339,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                 return item_type
             type_annotation = List[item_type]  # type: ignore
         elif isinstance(column.type, BigInteger):
-            type_annotation = Int64
+            type_annotation = BigInt
         else:
             for (
                 sqlalchemy_type,

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -92,6 +92,7 @@ from strawberry_sqlalchemy_mapper.relay import (
     resolve_model_node,
     resolve_model_nodes,
 )
+from strawberry_sqlalchemy_mapper.scalars import Int64
 
 if TYPE_CHECKING:
     from sqlalchemy.sql.expression import ColumnElement
@@ -179,7 +180,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
     ] = {
         Integer: int,
         Float: float,
-        BigInteger: int,
+        BigInteger: Int64,
         Numeric: Decimal,
         DateTime: datetime,
         Date: date,
@@ -337,6 +338,8 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
             if item_type is SkipTypeSentinel:
                 return item_type
             type_annotation = List[item_type]  # type: ignore
+        elif isinstance(column.type, BigInteger):
+            type_annotation = Int64
         else:
             for (
                 sqlalchemy_type,

--- a/src/strawberry_sqlalchemy_mapper/scalars.py
+++ b/src/strawberry_sqlalchemy_mapper/scalars.py
@@ -1,0 +1,10 @@
+from typing import Union
+
+import strawberry
+
+Int64 = strawberry.scalar(
+    Union[int, str],  # type: ignore
+    serialize=lambda v: int(v),
+    parse_value=lambda v: str(v),
+    description="Int64 field",
+)

--- a/src/strawberry_sqlalchemy_mapper/scalars.py
+++ b/src/strawberry_sqlalchemy_mapper/scalars.py
@@ -2,9 +2,9 @@ from typing import Union
 
 import strawberry
 
-Int64 = strawberry.scalar(
+BigInt = strawberry.scalar(
     Union[int, str],  # type: ignore
     serialize=lambda v: int(v),
     parse_value=lambda v: str(v),
-    description="Int64 field",
+    description="BigInt field",
 )


### PR DESCRIPTION
This PR fixes #100 by implementing a new custom scalar `Int64` following the strawberry documentation: https://strawberry.rocks/docs/types/scalars#int64

## Description

The new `Int64` custom scalar resolved issues of very large integers when using SQLAlchemy's `BigInteger`.

## Types of Changes

- [x] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #100 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
