### PR TITLE
Fix CI with new Ubuntu LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: python3 -m venv .venv
-      - run: source .venv/bin/activate
-      - run: pip install poetry nox nox-poetry
       - id: set-matrix
         shell: bash
         run: |
+          . .venv/bin/activate 
+          pip install poetry nox nox-poetry
           echo sessions=$(
             nox --json -t tests -l |
             jq 'map(

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
         if: steps.setup-python.outputs.cache-hit != 'true'
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v2
+        uses: CodSpeedHQ/action@v3
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: poetry run pytest tests/benchmarks --codspeed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,11 +20,13 @@ on:
 jobs:
   generate-jobs-tests:
     name: 💻 Generate test matrix
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       sessions: ${{ steps.set-matrix.outputs.sessions }}
     steps:
       - uses: actions/checkout@v4
+      - run: python3 -m venv .venv
+      - run: source .venv/bin/activate
       - run: pip install poetry nox nox-poetry
       - id: set-matrix
         shell: bash
@@ -76,7 +78,7 @@ jobs:
 
   benchmarks:
     name: 📈 Benchmarks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04 # Using this version because CodSpeed doesn't support Ubuntu 24.04 LTS yet.
     strategy:
       fail-fast: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   generate-jobs-tests:
     name: 💻 Generate test matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       sessions: ${{ steps.set-matrix.outputs.sessions }}
     steps:
@@ -76,7 +76,7 @@ jobs:
 
   benchmarks:
     name: 📈 Benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

Our CI started getting some new erros, I've checked that CodSpeed doesn't support Ubuntu 24.04 LTS (lastest LTS).
This PR fixes `Unit tests / 💻 Generate test matrix (pull_request)` and `Unit tests / 📈 Benchmarks (pull_request)` workflows by bring back ubuntu 22.04 on `Benchmarks` and using a Virtual Enviroment on `Generate Test Matrix` to follow [PEP 668 on new ubuntu version](https://peps.python.org/pep-0668/).

Is also important see that 22.04 LTS will be updated until [April 2027](https://ubuntu.com/about/release-cycle)

![image](https://github.com/user-attachments/assets/08cf7d9c-9089-4dea-a33d-dcac171b98f6)

![image](https://github.com/user-attachments/assets/eb29403a-ce11-4791-acf1-c05d14a7d5c8)



## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Fix CI workflows by switching to Ubuntu 22.04 LTS and updating CodSpeed action to version 3 to resolve compatibility issues.

CI:
- Update CI workflows to use Ubuntu 22.04 instead of the latest version to ensure compatibility with CodSpeed.