### PR TITLE
add missing page_info / cursors for Association Proxy logic 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes relay pagination logic fo association proxy logic.

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -596,7 +596,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                     outputs = await end_relationship_resolver(in_between_objects, info)
                 if not isinstance(outputs, collections.abc.Iterable):
                     return outputs
-                edges = [edge_type(node=obj) for obj in outputs]
+                edges = [edge_type(node=obj, cursor=None) for obj in outputs]
                 return connection_type(edges=edges,
                                        page_info=relay.PageInfo(
                                            has_next_page=False,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`association_proxy_resolver_for` has a few code blocks that were not updated for the relay changes. Association proxy mapping would fail due do constructors missing either `page_info` or `cursor` args. 

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* N/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


I haven't added tests as it looks like this code is originally untested.

## Summary by Sourcery

Bug Fixes:
- Fix association proxy mapping failures due to missing `page_info` or `cursor` arguments in constructors.