### PR TITLE
doc: Add directions for using dev containers

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,7 +113,7 @@ Clone the repository
    page. This creates a copy of the code under your account on |the repository service|.
 #. Clone this copy to your local disk::
 
-    git clone git@github.com:YourLogin/strawberry-sqlalchemy-mapper.git
+    git clone git@github.com:YOUR_USERNAME_HERE/strawberry-sqlalchemy-mapper.git
     cd strawberry-sqlalchemy-mapper
 
 Install dependencies and plugins

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -119,46 +119,48 @@ Clone the repository
 Install dependencies and plugins
 --------------------------------
 
-There are two ways to set up the environment for local development:
+.. todo:: Rewrite the following snippets to use the poetry environment rather than setuptools
 
-#. Manual environment setup
+   There are two ways to set up the environment for local development:
 
-#. Dev Container setup
+   #. Manual environment setup
 
-Method 1: Manual environment setup
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   #. Dev Container setup
 
-#. Before you start coding, we recommend creating an isolated `virtual
-   environment`_ to avoid any problems with your installed Python packages.
-   This can easily be done via either |virtualenv|_::
+   Method 1: Manual environment setup
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-      virtualenv <PATH TO VENV>
-      source <PATH TO VENV>/bin/activate
+   #. Before you start coding, we recommend creating an isolated `virtual
+      environment`_ to avoid any problems with your installed Python packages.
+      This can easily be done via either |virtualenv|_::
 
-   or Miniconda_::
+         virtualenv <PATH TO VENV>
+         source <PATH TO VENV>/bin/activate
 
-      conda create -n strawberry-sqlalchemy-mapper python=3 six virtualenv pytest pytest-cov
-      conda activate strawberry-sqlalchemy-mapper
+      or Miniconda_::
 
-#. You should run::
+         conda create -n strawberry-sqlalchemy-mapper python=3 six virtualenv pytest pytest-cov
+         conda activate strawberry-sqlalchemy-mapper
 
-    pip install -U pip setuptools -e .
+   #. You should run::
 
-   to be able to import the package under development in the Python REPL.
+      pip install -U pip setuptools -e .
 
-   .. todo:: if you are not using pre-commit, please remove the following item:
+      to be able to import the package under development in the Python REPL.
 
-#. Install |pre-commit|_::
+      .. todo:: if you are not using pre-commit, please remove the following item:
 
-    pip install pre-commit
-    pre-commit install
+   #. Install |pre-commit|_::
 
-   ``strawberry-sqlalchemy-mapper`` comes with a lot of hooks configured to automatically help the
-   developer to check the code being written.
+      pip install pre-commit
+      pre-commit install
+
+      ``strawberry-sqlalchemy-mapper`` comes with a lot of hooks configured to automatically help the
+      developer to check the code being written.
 
 
-Method 2: Dev Container setup
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   Method 2: Dev Container setup
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 #. Install `Dev Containers`_.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -145,21 +145,20 @@ Clone the repository
     git clone git@github.com:YourLogin/strawberry-sqlalchemy-mapper.git
     cd strawberry-sqlalchemy-mapper
 
-#. You should run::
+Open the Dev Container
+----------------------
 
-    pip install -U pip setuptools -e .
+#. Install `Dev Containers`_.
 
-   to be able to import the package under development in the Python REPL.
+#. Press ``Ctrl+Shift+P`` to open the command tab and enter ``Dev Containers: Open Folder in Container...``.
 
-   .. todo:: if you are not using pre-commit, please remove the following item:
+#. Select the root directory of this repository.
+   Dev Containers will now install the environment dependencies as well as |pre-commit|_
 
-#. Install |pre-commit|_::
+#. When installation is complete, press ``Ctrl+Shift+P`` to open the command tab and enter ``Python Select Interpreter``
 
-    pip install pre-commit
-    pre-commit install
+#. Select the environment labeled 'poetry'.
 
-   ``strawberry-sqlalchemy-mapper`` comes with a lot of hooks configured to automatically help the
-   developer to check the code being written.
 
 Implement your changes
 ----------------------
@@ -329,6 +328,7 @@ on PyPI_, the following steps can be used to release a new version for
 .. _contribution-guide.org: https://www.contribution-guide.org/
 .. _creating a PR: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 .. _descriptive commit message: https://chris.beams.io/posts/git-commit
+.. _Dev Containers: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers
 .. _docstrings: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
 .. _first-contributions tutorial: https://github.com/firstcontributions/first-contributions
 .. _flake8: https://flake8.pycqa.org/en/stable/

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -341,8 +341,8 @@ on PyPI_, the following steps can be used to release a new version for
 .. |the repository service| replace:: GitHub
 .. |contribute button| replace:: "Create pull request"
 
-.. _repository: https://github.com/<USERNAME>/strawberry-sqlalchemy-mapper
-.. _issue tracker: https://github.com/<USERNAME>/strawberry-sqlalchemy-mapper/issues
+.. _repository: https://github.com/strawberry-graphql/strawberry-sqlalchemy-mapper
+.. _issue tracker: https://github.com/strawberry-graphql/strawberry-sqlalchemy-mapper/issues
 .. <-- end -->
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -343,8 +343,8 @@ on PyPI_, the following steps can be used to release a new version for
 .. |the repository service| replace:: GitHub
 .. |contribute button| replace:: "Create pull request"
 
-.. _repository: https://github.com/strawberry-graphql/strawberry-sqlalchemy-mapper
-.. _issue tracker: https://github.com/strawberry-graphql/strawberry-sqlalchemy-mapper/issues
+.. _repository: https://github.com/strawberry-graphql/strawberry-sqlalchemy
+.. _issue tracker: https://github.com/strawberry-graphql/strawberry-sqlalchemy/issues
 .. <-- end -->
 
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,6 +102,75 @@ and use Python's built-in web server for a preview in your web browser
 
     python3 -m http.server --directory 'docs/_build/html'
 
+Project Setup
+=============
+
+Clone the repository
+--------------------
+
+#. Create an user account on |the repository service| if you do not already have one.
+#. Fork the project repository_: click on the *Fork* button near the top of the
+   page. This creates a copy of the code under your account on |the repository service|.
+#. Clone this copy to your local disk::
+
+    git clone git@github.com:YourLogin/strawberry-sqlalchemy-mapper.git
+    cd strawberry-sqlalchemy-mapper
+
+Install dependencies and plugins
+--------------------------------
+
+There are two ways to set up the environment for local development:
+
+#. Manual environment setup
+
+#. Dev Container setup
+
+Method 1: Manual environment setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Before you start coding, we recommend creating an isolated `virtual
+   environment`_ to avoid any problems with your installed Python packages.
+   This can easily be done via either |virtualenv|_::
+
+      virtualenv <PATH TO VENV>
+      source <PATH TO VENV>/bin/activate
+
+   or Miniconda_::
+
+      conda create -n strawberry-sqlalchemy-mapper python=3 six virtualenv pytest pytest-cov
+      conda activate strawberry-sqlalchemy-mapper
+
+#. You should run::
+
+    pip install -U pip setuptools -e .
+
+   to be able to import the package under development in the Python REPL.
+
+   .. todo:: if you are not using pre-commit, please remove the following item:
+
+#. Install |pre-commit|_::
+
+    pip install pre-commit
+    pre-commit install
+
+   ``strawberry-sqlalchemy-mapper`` comes with a lot of hooks configured to automatically help the
+   developer to check the code being written.
+
+
+Method 2: Dev Container setup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Install `Dev Containers`_.
+
+#. Press ``Ctrl+Shift+P`` to open the command tab and enter ``Dev Containers: Open Folder in Container...``.
+
+#. Select the root directory of this repository.
+   Dev Containers will now install the environment dependencies as well as |pre-commit|_
+
+#. When installation is complete, press ``Ctrl+Shift+P`` to open the command tab and enter ``Python Select Interpreter``
+
+#. Select the environment labeled 'poetry'.
+
 
 Code Contributions
 ==================
@@ -118,47 +187,6 @@ Submit an issue
 Before you work on any non-trivial code contribution it's best to first create
 a report in the `issue tracker`_ to start a discussion on the subject.
 This often provides additional considerations and avoids unnecessary work.
-
-Create an environment
----------------------
-
-Before you start coding, we recommend creating an isolated `virtual
-environment`_ to avoid any problems with your installed Python packages.
-This can easily be done via either |virtualenv|_::
-
-    virtualenv <PATH TO VENV>
-    source <PATH TO VENV>/bin/activate
-
-or Miniconda_::
-
-    conda create -n strawberry-sqlalchemy-mapper python=3 six virtualenv pytest pytest-cov
-    conda activate strawberry-sqlalchemy-mapper
-
-Clone the repository
---------------------
-
-#. Create an user account on |the repository service| if you do not already have one.
-#. Fork the project repository_: click on the *Fork* button near the top of the
-   page. This creates a copy of the code under your account on |the repository service|.
-#. Clone this copy to your local disk::
-
-    git clone git@github.com:YourLogin/strawberry-sqlalchemy-mapper.git
-    cd strawberry-sqlalchemy-mapper
-
-Open the Dev Container
-----------------------
-
-#. Install `Dev Containers`_.
-
-#. Press ``Ctrl+Shift+P`` to open the command tab and enter ``Dev Containers: Open Folder in Container...``.
-
-#. Select the root directory of this repository.
-   Dev Containers will now install the environment dependencies as well as |pre-commit|_
-
-#. When installation is complete, press ``Ctrl+Shift+P`` to open the command tab and enter ``Python Select Interpreter``
-
-#. Select the environment labeled 'poetry'.
-
 
 Implement your changes
 ----------------------

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ If you have a suggestion that would make this better, please fork the repo and c
 4. Push to the Branch (git push origin feature)
 5. Open a Pull Request
 
+For more details on how to contribute, as well as how to setup the project on your local machine, please refer to [the docs](CONTRIBUTING.rst)
+
 
 ### Prerequisites
 


### PR DESCRIPTION
Add directions to documentation for using dev containers

## Description

<!--- Describe your changes in detail here. -->
- Add directions to CONTRIBUTING.rst detailing the following
  - Installing Dev Containers extension
  - Opening repo in Dev Containers
  - Final environment setup
- Remove install `pre-commit`/`setuptools` instructions as this is handled automatically by Dev Containers

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

[192](https://github.com/strawberry-graphql/strawberry-sqlalchemy/issues/192)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Update the contributing documentation to include instructions for using dev containers, including installing the extension, opening the repo, and environment setup. Remove the pre-commit and setuptools installation instructions as they are now handled automatically by dev containers.

Documentation:
- Add instructions for using dev containers to the contributing documentation.
- Remove pre-commit and setuptools installation instructions.