### PR TITLE
add missing page_info / cursors for Association Proxy logic 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Fix association proxy mapping failures due to missing `page_info` or `cursor` arguments in constructors.
+Ensure association proxy resolvers return valid relay connections, including `page_info` and edge `cursor` details, even for empty results.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Fixes relay pagination logic fo association proxy logic.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 Release type: patch
 
-Fixes relay pagination logic fo association proxy logic.
+Fix association proxy mapping failures due to missing `page_info` or `cursor` arguments in constructors.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,5 @@
 Release type: patch
 
 Ensure association proxy resolvers return valid relay connections, including `page_info` and edge `cursor` details, even for empty results.
+
+Thanks to https://github.com/tylernisonoff for the original PR.

--- a/src/strawberry_sqlalchemy_mapper/exc.py
+++ b/src/strawberry_sqlalchemy_mapper/exc.py
@@ -10,7 +10,8 @@ class UnsupportedAssociationProxyTarget(Exception):
     def __init__(self, key):
         super().__init__(
             f"Association proxy `{key}` is expected to be of form "
-            + "association_proxy(relationship_name, other relationship name)"
+            + "association_proxy(relationship_name, other relationship name). "
+            + "Ensure it matches the expected form or add this association proxy to __exclude__."
         )
 
 

--- a/src/strawberry_sqlalchemy_mapper/exc.py
+++ b/src/strawberry_sqlalchemy_mapper/exc.py
@@ -2,7 +2,7 @@ class UnsupportedColumnType(Exception):
     def __init__(self, key, type):
         super().__init__(
             f"Unsupported column type: `{type}` on column: `{key}`. "
-            + "Possible fix: exclude this column"
+            "Possible fix: exclude this column"
         )
 
 
@@ -10,8 +10,8 @@ class UnsupportedAssociationProxyTarget(Exception):
     def __init__(self, key):
         super().__init__(
             f"Association proxy `{key}` is expected to be of form "
-            + "association_proxy(relationship_name, other relationship name). "
-            + "Ensure it matches the expected form or add this association proxy to __exclude__."
+            "association_proxy(relationship_name, other relationship name). "
+            "Ensure it matches the expected form or add this association proxy to __exclude__."
         )
 
 
@@ -19,7 +19,7 @@ class HybridPropertyNotAnnotated(Exception):
     def __init__(self, key):
         super().__init__(
             f"Descriptor `{key}` is a hybrid property, but does not have an "
-            + "annotated return type"
+            "annotated return type"
         )
 
 
@@ -27,7 +27,7 @@ class UnsupportedDescriptorType(Exception):
     def __init__(self, key):
         super().__init__(
             f"Descriptor `{key}` is expected to be a column, relationship, "
-            + "or association proxy."
+            "or association proxy."
         )
 
 
@@ -35,5 +35,5 @@ class InterfaceModelNotPolymorphic(Exception):
     def __init__(self, model):
         super().__init__(
             f"Model `{model}` is not polymorphic or is not the base model of its "
-            + "inheritance chain, and thus cannot be used as an interface."
+            "inheritance chain, and thus cannot be used as an interface."
         )

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -574,12 +574,14 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
             in_between_objects = await in_between_resolver(self, info)
             if in_between_objects is None:
                 if is_multiple:
-                    return connection_type(edges=[], page_info=relay.PageInfo(
-                        has_next_page=False,
-                        has_previous_page=False,
-                        start_cursor=None,
-                        end_cursor=None,
-                    ))
+                    return connection_type(
+                        edges=[], 
+                        page_info=relay.PageInfo(
+                            has_next_page=False,
+                            has_previous_page=False,
+                            start_cursor=None,
+                            end_cursor=None,
+                        ))
                 else:
                     return None
             if descriptor.value_attr in in_between_mapper.relationships:
@@ -600,13 +602,14 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                 if not isinstance(outputs, collections.abc.Iterable):
                     return outputs
                 edges = [edge_type(node=obj, cursor=None) for obj in outputs]
-                return connection_type(edges=edges,
-                                       page_info=relay.PageInfo(
-                                           has_next_page=False,
-                                           has_previous_page=False,
-                                           start_cursor=edges[0].cursor if edges else None,
-                                           end_cursor=edges[-1].cursor if edges else None,
-                                       ))
+                return connection_type(
+                    edges=edges,
+                    page_info=relay.PageInfo(
+                        has_previous_page=False,
+                        has_next_page=False,
+                        start_cursor=edges[0].cursor if edges else None,
+                        end_cursor=edges[-1].cursor if edges else None,
+                    ))
             else:
                 assert descriptor.value_attr in in_between_mapper.columns
                 if isinstance(in_between_objects, collections.abc.Iterable):

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -150,13 +150,11 @@ class StrawberrySQLAlchemyType(Generic[BaseModelType]):
 
     @overload
     @classmethod
-    def from_type(cls, type_: type, *, strict: Literal[True]) -> Self:
-        ...
+    def from_type(cls, type_: type, *, strict: Literal[True]) -> Self: ...
 
     @overload
     @classmethod
-    def from_type(cls, type_: type, *, strict: bool = False) -> Optional[Self]:
-        ...
+    def from_type(cls, type_: type, *, strict: bool = False) -> Optional[Self]: ...
 
     @classmethod
     def from_type(
@@ -498,7 +496,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
         """
 
         async def resolve(self, info: Info):
-            instance_state = cast(InstanceState, inspect(self))
+            instance_state = cast("InstanceState", inspect(self))
             if relationship.key not in instance_state.unloaded:
                 related_objects = getattr(self, relationship.key)
             else:
@@ -574,15 +572,18 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
             in_between_objects = await in_between_resolver(self, info)
             if in_between_objects is None:
                 if is_multiple:
-                    return connection_type(
-                        edges=[], 
-                        page_info=relay.PageInfo(
-                            has_next_page=False,
-                            has_previous_page=False,
-                            start_cursor=None,
-                            end_cursor=None,
-                        ))
+                    breakpoint()  # noqa: E702  # type: ignore[comment]
+                    return connection_type(edges=[])
+                    # return connection_type(
+                    #     edges=[],
+                    #     page_info=relay.PageInfo(
+                    #         has_next_page=False,
+                    #         has_previous_page=False,
+                    #         start_cursor=None,
+                    #         end_cursor=None,
+                    #     ))  # noqa: E501  # type: ignore[comment]
                 else:
+                    breakpoint()  # noqa: E702  # type: ignore[comment]
                     return None
             if descriptor.value_attr in in_between_mapper.relationships:
                 assert end_relationship_resolver is not None
@@ -601,15 +602,23 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                     outputs = await end_relationship_resolver(in_between_objects, info)
                 if not isinstance(outputs, collections.abc.Iterable):
                     return outputs
-                edges = [edge_type(node=obj, cursor=None) for obj in outputs]
+                # TODO: add this logic into a function
+                edges = [
+                    edge_type.resolve_edge(
+                        related_object,
+                        cursor=i,
+                    )
+                    for i, related_object in enumerate(outputs)
+                ]
                 return connection_type(
                     edges=edges,
                     page_info=relay.PageInfo(
-                        has_previous_page=False,
                         has_next_page=False,
+                        has_previous_page=False,
                         start_cursor=edges[0].cursor if edges else None,
                         end_cursor=edges[-1].cursor if edges else None,
-                    ))
+                    ),
+                )
             else:
                 assert descriptor.value_attr in in_between_mapper.columns
                 if isinstance(in_between_objects, collections.abc.Iterable):
@@ -682,7 +691,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
             type_.__annotations__ = {
                 k: v for k, v in old_annotations.items() if is_private(v)
             }
-            mapper: Mapper = cast(Mapper, inspect(model))
+            mapper: Mapper = cast("Mapper", inspect(model))
             generated_field_keys = []
 
             excluded_keys = getattr(type_, "__exclude__", [])
@@ -721,7 +730,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                     generated_field_keys,
                 )
                 sqlalchemy_field = cast(
-                    StrawberryField,
+                    "StrawberryField",
                     field(
                         resolver=self.connection_resolver_for(
                             relationship,
@@ -765,7 +774,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                         type_, key, strawberry_type, generated_field_keys
                     )
                     sqlalchemy_field = cast(
-                        StrawberryField,
+                        "StrawberryField",
                         field(
                             resolver=self.association_proxy_resolver_for(
                                 mapper,
@@ -836,7 +845,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                         setattr(
                             type_,
                             attr,
-                            types.MethodType(cast(classmethod, meth).__func__, type_),
+                            types.MethodType(cast("classmethod", meth).__func__, type_),
                         )
 
             # need to make fields that are already in the type

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -496,7 +496,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
         """
 
         async def resolve(self, info: Info):
-            instance_state = cast("InstanceState", inspect(self))
+            instance_state = cast(InstanceState, inspect(self))
             if relationship.key not in instance_state.unloaded:
                 related_objects = getattr(self, relationship.key)
             else:
@@ -572,18 +572,15 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
             in_between_objects = await in_between_resolver(self, info)
             if in_between_objects is None:
                 if is_multiple:
-                    breakpoint()  # noqa: E702  # type: ignore[comment]
-                    return connection_type(edges=[])
-                    # return connection_type(
-                    #     edges=[],
-                    #     page_info=relay.PageInfo(
-                    #         has_next_page=False,
-                    #         has_previous_page=False,
-                    #         start_cursor=None,
-                    #         end_cursor=None,
-                    #     ))  # noqa: E501  # type: ignore[comment]
+                    return connection_type(
+                        edges=[],
+                        page_info=relay.PageInfo(
+                            has_next_page=False,
+                            has_previous_page=False,
+                            start_cursor=None,
+                            end_cursor=None,
+                        ))  
                 else:
-                    breakpoint()  # noqa: E702  # type: ignore[comment]
                     return None
             if descriptor.value_attr in in_between_mapper.relationships:
                 assert end_relationship_resolver is not None

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -596,7 +596,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                     outputs = await end_relationship_resolver(in_between_objects, info)
                 if not isinstance(outputs, collections.abc.Iterable):
                     return outputs
-                edges = [edge_type(node=obj) for obj in outputs]
+                edges = [edge_type(node=obj, cursor=None) for obj in outputs]
                 return connection_type(edges=edges,
                                        page_info=relay.PageInfo(
                                            has_next_page=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,8 @@ SQLA2 = SQLA_VERSION >= version.parse("2.0")
 
 
 logging.basicConfig()
-log = logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
+log = logging.getLogger("sqlalchemy.engine")
+log.setLevel(logging.INFO)
 
 
 def _pick_unused_port():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ def mapper():
 
 
 @pytest.fixture
-def building_department_employee_tables_with_association_proxy_and_normal_relationship(
+def building_department_employee_tables_with_association_proxy(
     base,
 ):
     class Building(base):
@@ -152,32 +152,3 @@ def building_department_employee_tables_with_association_proxy_and_normal_relati
 
     return Building, Department, Employee
 
-
-@pytest.fixture
-def building_department_employee_tables_with_only_proxy_association(base):
-    class Building(base):
-        __tablename__ = "buildings"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-
-        departments = relationship("Department", back_populates="building")
-        employees = association_proxy("departments", "employees")
-
-    class Department(base):
-        __tablename__ = "departments"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-        building_id = Column(Integer, ForeignKey("buildings.id"))
-
-        building = relationship("Building", back_populates="departments")
-        employees = relationship("Employee", back_populates="department")
-
-    class Employee(base):
-        __tablename__ = "employees"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-        department_id = Column(Integer, ForeignKey("departments.id"))
-
-        department = relationship("Department", back_populates="employees")
-
-    return Building, Department, Employee

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ SQLA2 = SQLA_VERSION >= version.parse("2.0")
 
 
 logging.basicConfig()
-logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
+log = logging.getLogger("sqlalchemy.engine").setLevel(logging.INFO)
 
 
 def _pick_unused_port():
@@ -58,7 +58,7 @@ if platform.system() == "Windows":
     # Our windows test pipeline doesn't play nice with postgres because
     # Github Actions doesn't support containers on windows.
     # It would probably be nicer if we chcked if postgres is installed
-    logging.info("Skipping postgresql tests on Windows OS")
+    log.info("Skipping postgresql tests on Windows OS")
     SUPPORTED_DBS = []
 else:
     SUPPORTED_DBS = ["postgresql"]  # TODO: Add sqlite and mysql.
@@ -151,4 +151,3 @@ def building_department_employee_tables_with_association_proxy(
         department = relationship("Department", back_populates="employees")
 
     return Building, Department, Employee
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,13 +15,11 @@ import socket
 import pytest
 import sqlalchemy
 from packaging import version
-from sqlalchemy import Column, ForeignKey, Integer, String, orm
+from sqlalchemy import orm
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext import asyncio
-from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.ext.asyncio.engine import AsyncEngine
-from sqlalchemy.orm import relationship
 from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyMapper
 from testing.postgresql import Postgresql, PostgresqlFactory
 
@@ -120,35 +118,3 @@ def base():
 @pytest.fixture
 def mapper():
     return StrawberrySQLAlchemyMapper()
-
-
-@pytest.fixture
-def building_department_employee_tables_with_association_proxy(
-    base,
-):
-    class Building(base):
-        __tablename__ = "buildings"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-
-        departments = relationship("Department", back_populates="building")
-        employees = association_proxy("departments", "employees")
-
-    class Department(base):
-        __tablename__ = "departments"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-        building_id = Column(Integer, ForeignKey("buildings.id"))
-
-        building = relationship("Building", back_populates="departments")
-        employees = relationship("Employee", back_populates="department")
-
-    class Employee(base):
-        __tablename__ = "employees"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-        department_id = Column(Integer, ForeignKey("departments.id"))
-
-        department = relationship("Department", back_populates="employees")
-
-    return Building, Department, Employee

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -1,0 +1,353 @@
+import textwrap
+from typing import List
+
+import pytest
+import strawberry
+from sqlalchemy import Column, ForeignKey, Integer, String, select
+from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.orm import relationship
+from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyLoader
+from strawberry_sqlalchemy_mapper.exc import UnsupportedAssociationProxyTarget
+
+
+@pytest.fixture
+def employee_and_department_tables_with_wrong_association_proxy(base):
+    class Department(base):
+        __tablename__ = "department"
+        id = Column(Integer, autoincrement=True, primary_key=True)
+        name = Column(String, nullable=False)
+        employees = relationship("Employee", back_populates="department")
+        employee_names = association_proxy("employees", "name")
+
+    class Employee(base):
+        __tablename__ = "employee"
+        id = Column(Integer, autoincrement=True, primary_key=True)
+        name = Column(String, nullable=False)
+        department_id = Column(Integer, ForeignKey("department.id"))
+        department = relationship("Department", back_populates="employees")
+
+    return Employee, Department
+
+
+def test_relationships_schema_with_association_proxy_should_raise_UnsupportedAssociationProxyTarget(
+    employee_and_department_tables_with_wrong_association_proxy, mapper
+):
+
+    EmployeeModel, DepartmentModel = (
+        employee_and_department_tables_with_wrong_association_proxy
+    )
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        __exclude__ = ["password_hash"]
+
+    with pytest.raises(UnsupportedAssociationProxyTarget) as exc_info:
+
+        @mapper.type(DepartmentModel)
+        class Department:
+            pass
+
+    assert (
+        "Association proxy `employee_names` is expected to be of form association_proxy(relationship_name, other relationship name)"
+        in str(exc_info.value)
+    )
+
+
+def test_relationships_schema_with_association_proxy(
+    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    mapper,
+):
+
+    BuildingModel, DepartmentModel, EmployeeModel = (
+        building_department_employee_tables_with_association_proxy_and_normal_relationship
+    )
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def buildings(self) -> Building: ...
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    expected = '''
+type Building {
+  id: Int!
+  name: String!
+  departments: DepartmentConnection!
+  employees: EmployeeConnection!
+}
+
+type Department {
+  id: Int!
+  name: String!
+  buildingId: Int
+  building: Building
+  employees: EmployeeConnection!
+}
+
+type DepartmentConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+  edges: [DepartmentEdge!]!
+}
+
+type DepartmentEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: Department!
+}
+
+type Employee {
+  id: Int!
+  name: String!
+  departmentId: Int
+  department: Department
+}
+
+type EmployeeConnection {
+  """Pagination data for this connection"""
+  pageInfo: PageInfo!
+  edges: [EmployeeEdge!]!
+}
+
+type EmployeeEdge {
+  """A cursor for use in pagination"""
+  cursor: String!
+
+  """The item at the end of the edge"""
+  node: Employee!
+}
+
+"""Information to aid in pagination."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: String
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: String
+}
+
+type Query {
+  buildings: Building!
+}
+    '''
+    assert str(schema) == textwrap.dedent(expected).strip()
+
+
+def create_test_data(
+    session,
+    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+):
+    BuildingModel, DepartmentModel, EmployeeModel = (
+        building_department_employee_tables_with_association_proxy_and_normal_relationship
+    )
+
+    building = BuildingModel(id=1, name="Main Office")
+    department1 = DepartmentModel(id=2, name="Engineering")
+    department2 = DepartmentModel(id=3, name="Human Resources")
+    employee1 = EmployeeModel(id=4, name="Alice")
+    employee2 = EmployeeModel(id=5, name="Bob")
+
+    # Establish relationships
+    department1.employees.extend([employee1])
+    department2.employees.extend([employee2])
+    building.departments.extend([department1, department2])
+
+    session.add_all([building, department1, department2, employee1, employee2])
+    session.commit()
+    return building, department1, department2, employee1, employee2
+
+
+def query_to_test_association_proxy():
+    return """
+    query {
+      buildings {
+        id
+        name
+        employees {
+          pageInfo {
+            hasNextPage
+            hasPreviousPage
+            startCursor
+            endCursor
+          }
+          edges {
+            cursor
+            node {
+              id
+              name
+              department {
+                id
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+
+async def test_query_with_association_proxy_schema(
+    base,
+    engine,
+    sessionmaker,
+    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    mapper,
+):
+    base.metadata.create_all(engine)
+    session = sessionmaker()
+
+    BuildingModel, DepartmentModel, EmployeeModel = (
+        building_department_employee_tables_with_association_proxy_and_normal_relationship
+    )
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def buildings(self) -> List[Building]:
+            result = session.scalars(select(BuildingModel))
+            return result.all()
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    building, department1, department2, employee1, employee2 = create_test_data(
+        session,
+        building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    )
+
+    query = query_to_test_association_proxy()
+
+    result = await schema.execute(
+        query,
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+    session.close()
+
+    assert result.errors is None
+    assert result.data == {
+        "buildings": [
+            {
+                "id": building.id,
+                "name": building.name,
+                "employees": {
+                    "pageInfo": {
+                        "hasNextPage": False,
+                        "hasPreviousPage": False,
+                        "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+                        "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+                    },
+                    "edges": [
+                        {
+                            "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+                            "node": {
+                                "id": employee1.id,
+                                "name": employee1.name,
+                                "department": {
+                                    "id": department1.id,
+                                    "name": department1.name,
+                                },
+                            },
+                        },
+                        {
+                            "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+                            "node": {
+                                "id": employee2.id,
+                                "name": employee2.name,
+                                "department": {
+                                    "id": department2.id,
+                                    "name": department2.name,
+                                },
+                            },
+                        },
+                    ],
+                },
+            }
+        ]
+    }
+
+
+async def test_query_with_association_proxy_schema_with_empty_database(
+    base,
+    engine,
+    sessionmaker,
+    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    mapper,
+):
+    base.metadata.create_all(engine)
+    session = sessionmaker()
+
+    BuildingModel, DepartmentModel, EmployeeModel = (
+        building_department_employee_tables_with_association_proxy_and_normal_relationship
+    )
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def buildings(self) -> List[Building]:
+            result = session.scalars(select(BuildingModel))
+            return result.all()
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    query = query_to_test_association_proxy()
+
+    result = await schema.execute(
+        query,
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+    session.close()
+
+    assert result.errors is None
+    assert result.data == {"buildings": []}
+
+
+## TODO
+# test with keysetConnection

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -3,11 +3,15 @@ from typing import List
 
 import pytest
 import strawberry
+from strawberry import relay
 from sqlalchemy import Column, ForeignKey, Integer, String, select
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
-from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyLoader
+from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyLoader, connection
 from strawberry_sqlalchemy_mapper.exc import UnsupportedAssociationProxyTarget
+from strawberry_sqlalchemy_mapper.relay import KeysetConnection
+
+
 
 
 @pytest.fixture
@@ -48,18 +52,95 @@ def test_relationships_schema_with_association_proxy_should_raise_UnsupportedAss
             pass
 
     assert (
-        "Association proxy `employee_names` is expected to be of form association_proxy(relationship_name, other relationship name)"
+        "Association proxy `employee_names` is expected to be of form association_proxy(relationship_name, other relationship name). Ensure it matches the expected form or add this association proxy to __exclude__"
         in str(exc_info.value)
     )
 
 
+def test_relationships_schema_with_association_proxy_should_not_raise_UnsupportedAssociationProxyTarget_if_excluded(
+    employee_and_department_tables_with_wrong_association_proxy, mapper
+):
+
+    EmployeeModel, DepartmentModel = (
+        employee_and_department_tables_with_wrong_association_proxy
+    )
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+    
+    @mapper.type(DepartmentModel)
+    class Department:
+        __exclude__ = ["password_hash", "employee_names"]
+    
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def departments(self) -> Department: ...
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    expected = '''
+    type Department {
+      id: Int!
+      name: String!
+      employees: EmployeeConnection!
+    }
+
+    type Employee {
+      id: Int!
+      name: String!
+      departmentId: Int
+      department: Department
+    }
+
+    type EmployeeConnection {
+      """Pagination data for this connection"""
+      pageInfo: PageInfo!
+      edges: [EmployeeEdge!]!
+    }
+
+    type EmployeeEdge {
+      """A cursor for use in pagination"""
+      cursor: String!
+
+      """The item at the end of the edge"""
+      node: Employee!
+    }
+
+    """Information to aid in pagination."""
+    type PageInfo {
+      """When paginating forwards, are there more items?"""
+      hasNextPage: Boolean!
+
+      """When paginating backwards, are there more items?"""
+      hasPreviousPage: Boolean!
+
+      """When paginating backwards, the cursor to continue."""
+      startCursor: String
+
+      """When paginating forwards, the cursor to continue."""
+      endCursor: String
+    }
+
+    type Query {
+      departments: Department!
+    }
+    '''
+    assert str(schema) == textwrap.dedent(expected).strip()
+
+
+    
+
+
 def test_relationships_schema_with_association_proxy(
-    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    building_department_employee_tables_with_association_proxy,
     mapper,
 ):
 
     BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy_and_normal_relationship
+        building_department_employee_tables_with_association_proxy
     )
 
     @mapper.type(EmployeeModel)
@@ -157,13 +238,14 @@ type Query {
 
 def create_test_data(
     session,
-    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    building_department_employee_tables_with_association_proxy,
 ):
     BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy_and_normal_relationship
+        building_department_employee_tables_with_association_proxy
     )
 
     building = BuildingModel(id=1, name="Main Office")
+    building2 = BuildingModel(id=6, name="New Office")
     department1 = DepartmentModel(id=2, name="Engineering")
     department2 = DepartmentModel(id=3, name="Human Resources")
     employee1 = EmployeeModel(id=4, name="Alice")
@@ -174,9 +256,9 @@ def create_test_data(
     department2.employees.extend([employee2])
     building.departments.extend([department1, department2])
 
-    session.add_all([building, department1, department2, employee1, employee2])
+    session.add_all([building, building2, department1, department2, employee1, employee2])
     session.commit()
-    return building, department1, department2, employee1, employee2
+    return building, building2, department1, department2, employee1, employee2
 
 
 def query_to_test_association_proxy():
@@ -213,14 +295,14 @@ async def test_query_with_association_proxy_schema(
     base,
     engine,
     sessionmaker,
-    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    building_department_employee_tables_with_association_proxy,
     mapper,
 ):
     base.metadata.create_all(engine)
     session = sessionmaker()
 
     BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy_and_normal_relationship
+        building_department_employee_tables_with_association_proxy
     )
 
     @mapper.type(EmployeeModel)
@@ -245,9 +327,9 @@ async def test_query_with_association_proxy_schema(
     mapper.finalize()
     schema = strawberry.Schema(query=Query)
 
-    building, department1, department2, employee1, employee2 = create_test_data(
+    building, building2, department1, department2, employee1, employee2 = create_test_data(
         session,
-        building_department_employee_tables_with_association_proxy_and_normal_relationship,
+        building_department_employee_tables_with_association_proxy,
     )
 
     query = query_to_test_association_proxy()
@@ -296,6 +378,19 @@ async def test_query_with_association_proxy_schema(
                         },
                     ],
                 },
+            },
+            {
+                "id": building2.id,
+                "name": building2.name,
+                "employees": {
+                    "pageInfo": {
+                        "hasNextPage": False,
+                        "hasPreviousPage": False,
+                        "startCursor": None,
+                        "endCursor": None,
+                    },
+                    "edges": [],
+                },
             }
         ]
     }
@@ -305,14 +400,14 @@ async def test_query_with_association_proxy_schema_with_empty_database(
     base,
     engine,
     sessionmaker,
-    building_department_employee_tables_with_association_proxy_and_normal_relationship,
+    building_department_employee_tables_with_association_proxy,
     mapper,
 ):
     base.metadata.create_all(engine)
     session = sessionmaker()
 
     BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy_and_normal_relationship
+        building_department_employee_tables_with_association_proxy
     )
 
     @mapper.type(EmployeeModel)
@@ -349,5 +444,214 @@ async def test_query_with_association_proxy_schema_with_empty_database(
     assert result.data == {"buildings": []}
 
 
-## TODO
-# test with keysetConnection
+async def test_query_with_association_proxy_schema_keyset_connection(
+    base,
+    engine,
+    sessionmaker,
+    building_department_employee_tables_with_association_proxy,
+    mapper,
+):
+    base.metadata.create_all(engine)
+    session = sessionmaker()
+
+    BuildingModel, DepartmentModel, EmployeeModel = (
+        building_department_employee_tables_with_association_proxy
+    )
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building(relay.Node):
+        id: relay.NodeID[int]
+        name: str
+
+    @strawberry.type
+    class Query:
+        buildings: KeysetConnection[Building] = connection(sessionmaker=sessionmaker,
+            keyset=(BuildingModel.name,),
+        )
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    building, building2, department1, department2, employee1, employee2 = create_test_data(
+        session,
+        building_department_employee_tables_with_association_proxy,
+    )
+
+    query = query = """\
+    query Buildings($first: Int, $after: String) {
+      buildings(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        edges {
+          cursor
+          node {
+            id
+            name
+            employees {
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+              edges {
+                cursor
+                node {
+                  id
+                  name
+                  department {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    result = await schema.execute(
+        query,
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+
+    assert result.errors is None
+    assert result.data == {
+      "buildings": {
+      "pageInfo": {
+        "hasNextPage": False,
+        "hasPreviousPage": False,
+        "startCursor": f">s:{building.name}",
+        "endCursor": f">s:{building2.name}"
+      },
+      "edges": [
+        {
+        "cursor": f">s:{building.name}",
+        "node": {
+          "id": "QnVpbGRpbmc6MQ==",
+          "name": building.name,
+          "employees": {
+          "pageInfo": {
+            "hasNextPage": False,
+            "hasPreviousPage": False,
+            "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+            "endCursor": "YXJyYXljb25uZWN0aW9uOjE="
+          },
+          "edges": [
+            {
+            "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+            "node": {
+              "id": employee1.id,
+              "name": employee1.name,
+              "department": {
+              "id": department1.id,
+              "name": department1.name
+              }
+            }
+            },
+            {
+            "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+            "node": {
+              "id": employee2.id,
+              "name": employee2.name,
+              "department": {
+              "id": department2.id,
+              "name": department2.name
+              }
+            }
+            }
+          ]
+          }
+        }
+        },
+        {
+        "cursor": f">s:{building2.name}",
+        "node": {
+          "id": "QnVpbGRpbmc6Ng==",
+          "name": building2.name,
+          "employees": {
+          "pageInfo": {
+            "hasNextPage": False,
+            "hasPreviousPage": False,
+            "startCursor": None,
+            "endCursor": None
+          },
+          "edges": []
+          }
+        }
+        }
+      ]
+      }
+    }
+    
+    result = await schema.execute(
+        query,
+        {"first": 1},
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+    assert result.errors is None
+    assert result.data == {
+      "buildings": {
+      "pageInfo": {
+        "hasNextPage": True,
+        "hasPreviousPage": False,
+        "startCursor": f">s:{building.name}",
+        "endCursor": f">s:{building.name}"
+      },
+      "edges": [
+        {
+        "cursor": f">s:{building.name}",
+        "node": {
+          "id": "QnVpbGRpbmc6MQ==",
+          "name": building.name,
+          "employees": {
+          "pageInfo": {
+            "hasNextPage": False,
+            "hasPreviousPage": False,
+            "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+            "endCursor": "YXJyYXljb25uZWN0aW9uOjE="
+          },
+          "edges": [
+            {
+            "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+            "node": {
+              "id": employee1.id,
+              "name": employee1.name,
+              "department": {
+              "id": department1.id,
+              "name": department1.name
+              }
+            }
+            },
+            {
+            "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+            "node": {
+              "id": employee2.id,
+              "name": employee2.name,
+              "department": {
+              "id": department2.id,
+              "name": department2.name
+              }
+            }
+            }
+          ]
+          }
+        }
+        }
+      ]
+      }
+    }

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -3,15 +3,13 @@ from typing import List
 
 import pytest
 import strawberry
-from strawberry import relay
 from sqlalchemy import Column, ForeignKey, Integer, String, select
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
+from strawberry import relay
 from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyLoader, connection
 from strawberry_sqlalchemy_mapper.exc import UnsupportedAssociationProxyTarget
 from strawberry_sqlalchemy_mapper.relay import KeysetConnection
-
-
 
 
 @pytest.fixture
@@ -68,11 +66,11 @@ def test_relationships_schema_with_association_proxy_should_not_raise_Unsupporte
     @mapper.type(EmployeeModel)
     class Employee:
         pass
-    
+
     @mapper.type(DepartmentModel)
     class Department:
         __exclude__ = ["password_hash", "employee_names"]
-    
+
     @strawberry.type
     class Query:
         @strawberry.field
@@ -129,9 +127,6 @@ def test_relationships_schema_with_association_proxy_should_not_raise_Unsupporte
     }
     '''
     assert str(schema) == textwrap.dedent(expected).strip()
-
-
-    
 
 
 def test_relationships_schema_with_association_proxy(
@@ -256,7 +251,9 @@ def create_test_data(
     department2.employees.extend([employee2])
     building.departments.extend([department1, department2])
 
-    session.add_all([building, building2, department1, department2, employee1, employee2])
+    session.add_all(
+        [building, building2, department1, department2, employee1, employee2]
+    )
     session.commit()
     return building, building2, department1, department2, employee1, employee2
 
@@ -327,9 +324,11 @@ async def test_query_with_association_proxy_schema(
     mapper.finalize()
     schema = strawberry.Schema(query=Query)
 
-    building, building2, department1, department2, employee1, employee2 = create_test_data(
-        session,
-        building_department_employee_tables_with_association_proxy,
+    building, building2, department1, department2, employee1, employee2 = (
+        create_test_data(
+            session,
+            building_department_employee_tables_with_association_proxy,
+        )
     )
 
     query = query_to_test_association_proxy()
@@ -391,7 +390,7 @@ async def test_query_with_association_proxy_schema(
                     },
                     "edges": [],
                 },
-            }
+            },
         ]
     }
 
@@ -473,19 +472,22 @@ async def test_query_with_association_proxy_schema_keyset_connection(
 
     @strawberry.type
     class Query:
-        buildings: KeysetConnection[Building] = connection(sessionmaker=sessionmaker,
+        buildings: KeysetConnection[Building] = connection(
+            sessionmaker=sessionmaker,
             keyset=(BuildingModel.name,),
         )
 
     mapper.finalize()
     schema = strawberry.Schema(query=Query)
 
-    building, building2, department1, department2, employee1, employee2 = create_test_data(
-        session,
-        building_department_employee_tables_with_association_proxy,
+    building, building2, department1, department2, employee1, employee2 = (
+        create_test_data(
+            session,
+            building_department_employee_tables_with_association_proxy,
+        )
     )
 
-    query = query = """\
+    query = """
     query Buildings($first: Int, $after: String) {
       buildings(first: $first, after: $after) {
         pageInfo {
@@ -531,73 +533,73 @@ async def test_query_with_association_proxy_schema_keyset_connection(
 
     assert result.errors is None
     assert result.data == {
-      "buildings": {
-      "pageInfo": {
-        "hasNextPage": False,
-        "hasPreviousPage": False,
-        "startCursor": f">s:{building.name}",
-        "endCursor": f">s:{building2.name}"
-      },
-      "edges": [
-        {
-        "cursor": f">s:{building.name}",
-        "node": {
-          "id": "QnVpbGRpbmc6MQ==",
-          "name": building.name,
-          "employees": {
-          "pageInfo": {
-            "hasNextPage": False,
-            "hasPreviousPage": False,
-            "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
-            "endCursor": "YXJyYXljb25uZWN0aW9uOjE="
-          },
-          "edges": [
-            {
-            "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-            "node": {
-              "id": employee1.id,
-              "name": employee1.name,
-              "department": {
-              "id": department1.id,
-              "name": department1.name
-              }
-            }
+        "buildings": {
+            "pageInfo": {
+                "hasNextPage": False,
+                "hasPreviousPage": False,
+                "startCursor": f">s:{building.name}",
+                "endCursor": f">s:{building2.name}",
             },
-            {
-            "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-            "node": {
-              "id": employee2.id,
-              "name": employee2.name,
-              "department": {
-              "id": department2.id,
-              "name": department2.name
-              }
-            }
-            }
-          ]
-          }
+            "edges": [
+                {
+                    "cursor": f">s:{building.name}",
+                    "node": {
+                        "id": "QnVpbGRpbmc6MQ==",
+                        "name": building.name,
+                        "employees": {
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "hasPreviousPage": False,
+                                "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+                                "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+                            },
+                            "edges": [
+                                {
+                                    "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+                                    "node": {
+                                        "id": employee1.id,
+                                        "name": employee1.name,
+                                        "department": {
+                                            "id": department1.id,
+                                            "name": department1.name,
+                                        },
+                                    },
+                                },
+                                {
+                                    "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+                                    "node": {
+                                        "id": employee2.id,
+                                        "name": employee2.name,
+                                        "department": {
+                                            "id": department2.id,
+                                            "name": department2.name,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+                {
+                    "cursor": f">s:{building2.name}",
+                    "node": {
+                        "id": "QnVpbGRpbmc6Ng==",
+                        "name": building2.name,
+                        "employees": {
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "hasPreviousPage": False,
+                                "startCursor": None,
+                                "endCursor": None,
+                            },
+                            "edges": [],
+                        },
+                    },
+                },
+            ],
         }
-        },
-        {
-        "cursor": f">s:{building2.name}",
-        "node": {
-          "id": "QnVpbGRpbmc6Ng==",
-          "name": building2.name,
-          "employees": {
-          "pageInfo": {
-            "hasNextPage": False,
-            "hasPreviousPage": False,
-            "startCursor": None,
-            "endCursor": None
-          },
-          "edges": []
-          }
-        }
-        }
-      ]
-      }
     }
-    
+
     result = await schema.execute(
         query,
         {"first": 1},
@@ -605,53 +607,53 @@ async def test_query_with_association_proxy_schema_keyset_connection(
     )
     assert result.errors is None
     assert result.data == {
-      "buildings": {
-      "pageInfo": {
-        "hasNextPage": True,
-        "hasPreviousPage": False,
-        "startCursor": f">s:{building.name}",
-        "endCursor": f">s:{building.name}"
-      },
-      "edges": [
-        {
-        "cursor": f">s:{building.name}",
-        "node": {
-          "id": "QnVpbGRpbmc6MQ==",
-          "name": building.name,
-          "employees": {
-          "pageInfo": {
-            "hasNextPage": False,
-            "hasPreviousPage": False,
-            "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
-            "endCursor": "YXJyYXljb25uZWN0aW9uOjE="
-          },
-          "edges": [
-            {
-            "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
-            "node": {
-              "id": employee1.id,
-              "name": employee1.name,
-              "department": {
-              "id": department1.id,
-              "name": department1.name
-              }
-            }
+        "buildings": {
+            "pageInfo": {
+                "hasNextPage": True,
+                "hasPreviousPage": False,
+                "startCursor": f">s:{building.name}",
+                "endCursor": f">s:{building.name}",
             },
-            {
-            "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
-            "node": {
-              "id": employee2.id,
-              "name": employee2.name,
-              "department": {
-              "id": department2.id,
-              "name": department2.name
-              }
-            }
-            }
-          ]
-          }
+            "edges": [
+                {
+                    "cursor": f">s:{building.name}",
+                    "node": {
+                        "id": "QnVpbGRpbmc6MQ==",
+                        "name": building.name,
+                        "employees": {
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "hasPreviousPage": False,
+                                "startCursor": "YXJyYXljb25uZWN0aW9uOjA=",
+                                "endCursor": "YXJyYXljb25uZWN0aW9uOjE=",
+                            },
+                            "edges": [
+                                {
+                                    "cursor": "YXJyYXljb25uZWN0aW9uOjA=",
+                                    "node": {
+                                        "id": employee1.id,
+                                        "name": employee1.name,
+                                        "department": {
+                                            "id": department1.id,
+                                            "name": department1.name,
+                                        },
+                                    },
+                                },
+                                {
+                                    "cursor": "YXJyYXljb25uZWN0aW9uOjE=",
+                                    "node": {
+                                        "id": employee2.id,
+                                        "name": employee2.name,
+                                        "department": {
+                                            "id": department2.id,
+                                            "name": department2.name,
+                                        },
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                }
+            ],
         }
-        }
-      ]
-      }
     }

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -11,9 +11,11 @@ from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyLoader, connection
 from strawberry_sqlalchemy_mapper.exc import UnsupportedAssociationProxyTarget
 from strawberry_sqlalchemy_mapper.relay import KeysetConnection
 
+# === TABLES FIXTURES ===
+
 
 @pytest.fixture
-def employee_and_department_tables_with_wrong_association_proxy(base):
+def tables_with_wrong_association_proxy(base):
     class Department(base):
         __tablename__ = "department"
         id = Column(Integer, autoincrement=True, primary_key=True)
@@ -31,13 +33,89 @@ def employee_and_department_tables_with_wrong_association_proxy(base):
     return Employee, Department
 
 
+@pytest.fixture
+def tables_with_association_proxy(
+    base,
+):
+    class Building(base):
+        __tablename__ = "buildings"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+
+        departments = relationship("Department", back_populates="building")
+        employees = association_proxy("departments", "employees")
+
+    class Department(base):
+        __tablename__ = "departments"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+        building_id = Column(Integer, ForeignKey("buildings.id"))
+
+        building = relationship("Building", back_populates="departments")
+        employees = relationship("Employee", back_populates="department")
+
+    class Employee(base):
+        __tablename__ = "employees"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+        department_id = Column(Integer, ForeignKey("departments.id"))
+
+        department = relationship("Department", back_populates="employees")
+
+    return Building, Department, Employee
+
+
+@pytest.fixture
+def tables_with_association_proxy_and_nullable_relationship(
+    base,
+):
+    class Building(base):
+        __tablename__ = "buildings"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+
+        department_id = Column(Integer, ForeignKey("departments.id"), nullable=True)
+        department = relationship(
+            "Department",
+            back_populates="building",
+            foreign_keys=[department_id],
+            uselist=False,
+        )
+
+        employees = association_proxy("department", "employees")
+
+    class Department(base):
+        __tablename__ = "departments"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+
+        building = relationship(
+            "Building",
+            back_populates="department",
+            foreign_keys=[Building.department_id],
+        )
+
+        employees = relationship("Employee", back_populates="department")
+
+    class Employee(base):
+        __tablename__ = "employees"
+        id = Column(Integer, primary_key=True)
+        name = Column(String, nullable=False)
+        department_id = Column(Integer, ForeignKey("departments.id"))
+
+        department = relationship("Department", back_populates="employees")
+
+    return Building, Department, Employee
+
+
+# === TESTS ===
+
+
 def test_relationships_schema_with_association_proxy_should_raise_UnsupportedAssociationProxyTarget(
-    employee_and_department_tables_with_wrong_association_proxy, mapper
+    tables_with_wrong_association_proxy, mapper
 ):
 
-    EmployeeModel, DepartmentModel = (
-        employee_and_department_tables_with_wrong_association_proxy
-    )
+    EmployeeModel, DepartmentModel = tables_with_wrong_association_proxy
 
     @mapper.type(EmployeeModel)
     class Employee:
@@ -56,12 +134,10 @@ def test_relationships_schema_with_association_proxy_should_raise_UnsupportedAss
 
 
 def test_relationships_schema_with_association_proxy_should_not_raise_UnsupportedAssociationProxyTarget_if_excluded(
-    employee_and_department_tables_with_wrong_association_proxy, mapper
+    tables_with_wrong_association_proxy, mapper
 ):
 
-    EmployeeModel, DepartmentModel = (
-        employee_and_department_tables_with_wrong_association_proxy
-    )
+    EmployeeModel, DepartmentModel = tables_with_wrong_association_proxy
 
     @mapper.type(EmployeeModel)
     class Employee:
@@ -79,7 +155,274 @@ def test_relationships_schema_with_association_proxy_should_not_raise_Unsupporte
     mapper.finalize()
     schema = strawberry.Schema(query=Query)
 
-    expected = '''
+    expected = (
+        get_test_relationships_schema_with_association_proxy_should_not_raise_UnsupportedAssociationProxyTarget_if_excluded_expected_shema()
+    )
+    assert str(schema) == textwrap.dedent(expected).strip()
+
+
+def test_relationships_schema_with_association_proxy(
+    tables_with_association_proxy,
+    mapper,
+):
+
+    BuildingModel, DepartmentModel, EmployeeModel = tables_with_association_proxy
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def buildings(self) -> Building: ...
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    expected = get_test_relationships_schema_with_association_proxy_expected_schema()
+    assert str(schema) == textwrap.dedent(expected).strip()
+
+
+async def test_query_with_association_proxy_schema(
+    base,
+    engine,
+    sessionmaker,
+    tables_with_association_proxy,
+    mapper,
+):
+    base.metadata.create_all(engine)
+    session = sessionmaker()
+
+    BuildingModel, DepartmentModel, EmployeeModel = tables_with_association_proxy
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def buildings(self) -> List[Building]:
+            result = session.scalars(select(BuildingModel))
+            return result.all()
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    test_data = create_test_data(
+        session,
+        tables_with_association_proxy,
+    )
+
+    query = query_to_test_association_proxy()
+
+    result = await schema.execute(
+        query,
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+    session.close()
+
+    assert result.errors is None
+    assert result.data == get_test_query_with_association_proxy_schema_expected_result(
+        *test_data
+    )
+
+
+async def test_query_with_association_proxy_schema_with_empty_database(
+    base,
+    engine,
+    sessionmaker,
+    tables_with_association_proxy,
+    mapper,
+):
+    base.metadata.create_all(engine)
+    session = sessionmaker()
+
+    BuildingModel, DepartmentModel, EmployeeModel = tables_with_association_proxy
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def buildings(self) -> List[Building]:
+            result = session.scalars(select(BuildingModel))
+            return result.all()
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    query = query_to_test_association_proxy()
+
+    result = await schema.execute(
+        query,
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+    session.close()
+
+    assert result.errors is None
+    assert result.data == {"buildings": []}
+
+
+async def test_query_with_association_proxy_schema_keyset_connection(
+    base,
+    engine,
+    sessionmaker,
+    tables_with_association_proxy,
+    mapper,
+):
+    base.metadata.create_all(engine)
+    session = sessionmaker()
+
+    BuildingModel, DepartmentModel, EmployeeModel = tables_with_association_proxy
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building(relay.Node):
+        id: relay.NodeID[int]
+        name: str
+
+    @strawberry.type
+    class Query:
+        buildings: KeysetConnection[Building] = connection(
+            sessionmaker=sessionmaker,
+            keyset=(BuildingModel.name,),
+        )
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    test_data = create_test_data(
+        session,
+        tables_with_association_proxy,
+    )
+
+    query = get_test_query_with_association_proxy_schema_keyset_connection_query()
+
+    result = await schema.execute(
+        query,
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+
+    assert result.errors is None
+    assert (
+        result.data
+        == get_test_query_with_association_proxy_schema_keyset_connection_expected_result(
+            *test_data
+        )
+    )
+
+    result = await schema.execute(
+        query,
+        {"first": 1},
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+    assert result.errors is None
+    assert (
+        result.data
+        == get_test_query_with_association_proxy_schema_keyset_connection_expected_result_with_first(
+            *test_data
+        )
+    )
+
+
+async def test_query_with_association_proxy_schema_with_nullable_relationship(
+    base,
+    engine,
+    sessionmaker,
+    tables_with_association_proxy_and_nullable_relationship,
+    mapper,
+):
+    base.metadata.create_all(engine)
+    session = sessionmaker()
+
+    BuildingModel, DepartmentModel, EmployeeModel = (
+        tables_with_association_proxy_and_nullable_relationship
+    )
+
+    @mapper.type(EmployeeModel)
+    class Employee:
+        pass
+
+    @mapper.type(DepartmentModel)
+    class Department:
+        pass
+
+    @mapper.type(BuildingModel)
+    class Building:
+        pass
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        async def buildings(self) -> List[Building]:
+            result = session.scalars(select(BuildingModel))
+            return result.all()
+
+    mapper.finalize()
+    schema = strawberry.Schema(query=Query)
+
+    test_data = create_test_data_with_nullable_relationship(
+        session,
+        tables_with_association_proxy_and_nullable_relationship,
+    )
+
+    query = query_to_test_association_proxy()
+
+    result = await schema.execute(
+        query,
+        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
+    )
+    session.close()
+
+    assert result.errors is None
+    assert (
+        result.data
+        == get_test_query_with_association_proxy_schema_with_nullable_relationship_expected_result(
+            *test_data
+        )
+    )
+
+
+# === HELPERS ===
+
+
+def get_test_relationships_schema_with_association_proxy_should_not_raise_UnsupportedAssociationProxyTarget_if_excluded_expected_shema():
+    return '''
     type Department {
       id: Int!
       name: String!
@@ -126,39 +469,10 @@ def test_relationships_schema_with_association_proxy_should_not_raise_Unsupporte
       departments: Department!
     }
     '''
-    assert str(schema) == textwrap.dedent(expected).strip()
 
 
-def test_relationships_schema_with_association_proxy(
-    building_department_employee_tables_with_association_proxy,
-    mapper,
-):
-
-    BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy
-    )
-
-    @mapper.type(EmployeeModel)
-    class Employee:
-        pass
-
-    @mapper.type(DepartmentModel)
-    class Department:
-        pass
-
-    @mapper.type(BuildingModel)
-    class Building:
-        pass
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        def buildings(self) -> Building: ...
-
-    mapper.finalize()
-    schema = strawberry.Schema(query=Query)
-
-    expected = '''
+def get_test_relationships_schema_with_association_proxy_expected_schema():
+    return '''
 type Building {
   id: Int!
   name: String!
@@ -228,7 +542,6 @@ type Query {
   buildings: Building!
 }
     '''
-    assert str(schema) == textwrap.dedent(expected).strip()
 
 
 def create_test_data(
@@ -237,7 +550,7 @@ def create_test_data(
 ):
     BuildingModel, DepartmentModel, EmployeeModel = building_department_employee_tables
 
-    building = BuildingModel(id=1, name="Main Office")
+    building1 = BuildingModel(id=1, name="Main Office")
     building2 = BuildingModel(id=6, name="New Office")
     department1 = DepartmentModel(id=2, name="Engineering")
     department2 = DepartmentModel(id=3, name="Human Resources")
@@ -247,13 +560,13 @@ def create_test_data(
     # Establish relationships
     department1.employees.extend([employee1])
     department2.employees.extend([employee2])
-    building.departments.extend([department1, department2])
+    building1.departments.extend([department1, department2])
 
     session.add_all(
-        [building, building2, department1, department2, employee1, employee2]
+        [building1, building2, department1, department2, employee1, employee2]
     )
     session.commit()
-    return building, building2, department1, department2, employee1, employee2
+    return [building1, building2, department1, department2, employee1, employee2]
 
 
 def query_to_test_association_proxy():
@@ -286,95 +599,14 @@ def query_to_test_association_proxy():
     """
 
 
-@pytest.fixture
-def building_department_employee_tables_with_association_proxy(
-    base,
+def get_test_query_with_association_proxy_schema_expected_result(
+    building1, building2, department1, department2, employee1, employee2
 ):
-    class Building(base):
-        __tablename__ = "buildings"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-
-        departments = relationship("Department", back_populates="building")
-        employees = association_proxy("departments", "employees")
-
-    class Department(base):
-        __tablename__ = "departments"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-        building_id = Column(Integer, ForeignKey("buildings.id"))
-
-        building = relationship("Building", back_populates="departments")
-        employees = relationship("Employee", back_populates="department")
-
-    class Employee(base):
-        __tablename__ = "employees"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-        department_id = Column(Integer, ForeignKey("departments.id"))
-
-        department = relationship("Department", back_populates="employees")
-
-    return Building, Department, Employee
-
-
-async def test_query_with_association_proxy_schema(
-    base,
-    engine,
-    sessionmaker,
-    building_department_employee_tables_with_association_proxy,
-    mapper,
-):
-    base.metadata.create_all(engine)
-    session = sessionmaker()
-
-    BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy
-    )
-
-    @mapper.type(EmployeeModel)
-    class Employee:
-        pass
-
-    @mapper.type(DepartmentModel)
-    class Department:
-        pass
-
-    @mapper.type(BuildingModel)
-    class Building:
-        pass
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        async def buildings(self) -> List[Building]:
-            result = session.scalars(select(BuildingModel))
-            return result.all()
-
-    mapper.finalize()
-    schema = strawberry.Schema(query=Query)
-
-    building, building2, department1, department2, employee1, employee2 = (
-        create_test_data(
-            session,
-            building_department_employee_tables_with_association_proxy,
-        )
-    )
-
-    query = query_to_test_association_proxy()
-
-    result = await schema.execute(
-        query,
-        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
-    )
-    session.close()
-
-    assert result.errors is None
-    assert result.data == {
+    return {
         "buildings": [
             {
-                "id": building.id,
-                "name": building.name,
+                "id": building1.id,
+                "name": building1.name,
                 "employees": {
                     "pageInfo": {
                         "hasNextPage": False,
@@ -425,99 +657,8 @@ async def test_query_with_association_proxy_schema(
     }
 
 
-async def test_query_with_association_proxy_schema_with_empty_database(
-    base,
-    engine,
-    sessionmaker,
-    building_department_employee_tables_with_association_proxy,
-    mapper,
-):
-    base.metadata.create_all(engine)
-    session = sessionmaker()
-
-    BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy
-    )
-
-    @mapper.type(EmployeeModel)
-    class Employee:
-        pass
-
-    @mapper.type(DepartmentModel)
-    class Department:
-        pass
-
-    @mapper.type(BuildingModel)
-    class Building:
-        pass
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        async def buildings(self) -> List[Building]:
-            result = session.scalars(select(BuildingModel))
-            return result.all()
-
-    mapper.finalize()
-    schema = strawberry.Schema(query=Query)
-
-    query = query_to_test_association_proxy()
-
-    result = await schema.execute(
-        query,
-        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
-    )
-    session.close()
-
-    assert result.errors is None
-    assert result.data == {"buildings": []}
-
-
-async def test_query_with_association_proxy_schema_keyset_connection(
-    base,
-    engine,
-    sessionmaker,
-    building_department_employee_tables_with_association_proxy,
-    mapper,
-):
-    base.metadata.create_all(engine)
-    session = sessionmaker()
-
-    BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy
-    )
-
-    @mapper.type(EmployeeModel)
-    class Employee:
-        pass
-
-    @mapper.type(DepartmentModel)
-    class Department:
-        pass
-
-    @mapper.type(BuildingModel)
-    class Building(relay.Node):
-        id: relay.NodeID[int]
-        name: str
-
-    @strawberry.type
-    class Query:
-        buildings: KeysetConnection[Building] = connection(
-            sessionmaker=sessionmaker,
-            keyset=(BuildingModel.name,),
-        )
-
-    mapper.finalize()
-    schema = strawberry.Schema(query=Query)
-
-    building, building2, department1, department2, employee1, employee2 = (
-        create_test_data(
-            session,
-            building_department_employee_tables_with_association_proxy,
-        )
-    )
-
-    query = """
+def get_test_query_with_association_proxy_schema_keyset_connection_query():
+    return """
     query Buildings($first: Int, $after: String) {
       buildings(first: $first, after: $after) {
         pageInfo {
@@ -556,26 +697,24 @@ async def test_query_with_association_proxy_schema_keyset_connection(
     }
     """
 
-    result = await schema.execute(
-        query,
-        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
-    )
 
-    assert result.errors is None
-    assert result.data == {
+def get_test_query_with_association_proxy_schema_keyset_connection_expected_result(
+    building1, building2, department1, department2, employee1, employee2
+):
+    return {
         "buildings": {
             "pageInfo": {
                 "hasNextPage": False,
                 "hasPreviousPage": False,
-                "startCursor": f">s:{building.name}",
+                "startCursor": f">s:{building1.name}",
                 "endCursor": f">s:{building2.name}",
             },
             "edges": [
                 {
-                    "cursor": f">s:{building.name}",
+                    "cursor": f">s:{building1.name}",
                     "node": {
                         "id": "QnVpbGRpbmc6MQ==",
-                        "name": building.name,
+                        "name": building1.name,
                         "employees": {
                             "pageInfo": {
                                 "hasNextPage": False,
@@ -630,26 +769,24 @@ async def test_query_with_association_proxy_schema_keyset_connection(
         }
     }
 
-    result = await schema.execute(
-        query,
-        {"first": 1},
-        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
-    )
-    assert result.errors is None
-    assert result.data == {
+
+def get_test_query_with_association_proxy_schema_keyset_connection_expected_result_with_first(
+    building1, building2, department1, department2, employee1, employee2
+):
+    return {
         "buildings": {
             "pageInfo": {
                 "hasNextPage": True,
                 "hasPreviousPage": False,
-                "startCursor": f">s:{building.name}",
-                "endCursor": f">s:{building.name}",
+                "startCursor": f">s:{building1.name}",
+                "endCursor": f">s:{building1.name}",
             },
             "edges": [
                 {
-                    "cursor": f">s:{building.name}",
+                    "cursor": f">s:{building1.name}",
                     "node": {
                         "id": "QnVpbGRpbmc6MQ==",
-                        "name": building.name,
+                        "name": building1.name,
                         "employees": {
                             "pageInfo": {
                                 "hasNextPage": False,
@@ -689,56 +826,13 @@ async def test_query_with_association_proxy_schema_keyset_connection(
     }
 
 
-@pytest.fixture
-def building_department_employee_tables_with_association_proxy_and_null_relationship(
-    base,
-):
-    class Building(base):
-        __tablename__ = "buildings"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-
-        department_id = Column(Integer, ForeignKey("departments.id"), nullable=True)
-        department = relationship(
-            "Department",
-            back_populates="building",
-            foreign_keys=[department_id],
-            uselist=False,
-        )
-
-        employees = association_proxy("department", "employees")
-
-    class Department(base):
-        __tablename__ = "departments"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-
-        building = relationship(
-            "Building",
-            back_populates="department",
-            foreign_keys=[Building.department_id],
-        )
-
-        employees = relationship("Employee", back_populates="department")
-
-    class Employee(base):
-        __tablename__ = "employees"
-        id = Column(Integer, primary_key=True)
-        name = Column(String, nullable=False)
-        department_id = Column(Integer, ForeignKey("departments.id"))
-
-        department = relationship("Department", back_populates="employees")
-
-    return Building, Department, Employee
-
-
-def create_test_data_with_null_relationship(
+def create_test_data_with_nullable_relationship(
     session,
     building_department_employee_tables,
 ):
     BuildingModel, DepartmentModel, EmployeeModel = building_department_employee_tables
 
-    building = BuildingModel(id=1, name="Main Office")
+    building1 = BuildingModel(id=1, name="Main Office")
     building2 = BuildingModel(id=6, name="New Office")
     department1 = DepartmentModel(id=2, name="Engineering")
     department2 = DepartmentModel(id=3, name="Human Resources")
@@ -751,69 +845,20 @@ def create_test_data_with_null_relationship(
     building2.department = department2
 
     session.add_all(
-        [building, building2, department1, department2, employee1, employee2]
+        [building1, building2, department1, department2, employee1, employee2]
     )
     session.commit()
-    return building, building2, department1, department2, employee1, employee2
+    return building1, building2, department1, department2, employee1, employee2
 
 
-async def test_query_with_association_proxy_schema_with_null_relationship(
-    base,
-    engine,
-    sessionmaker,
-    building_department_employee_tables_with_association_proxy_and_null_relationship,
-    mapper,
+def get_test_query_with_association_proxy_schema_with_nullable_relationship_expected_result(
+    building1, building2, department1, department2, employee1, employee2
 ):
-    base.metadata.create_all(engine)
-    session = sessionmaker()
-
-    BuildingModel, DepartmentModel, EmployeeModel = (
-        building_department_employee_tables_with_association_proxy_and_null_relationship
-    )
-
-    @mapper.type(EmployeeModel)
-    class Employee:
-        pass
-
-    @mapper.type(DepartmentModel)
-    class Department:
-        pass
-
-    @mapper.type(BuildingModel)
-    class Building:
-        pass
-
-    @strawberry.type
-    class Query:
-        @strawberry.field
-        async def buildings(self) -> List[Building]:
-            result = session.scalars(select(BuildingModel))
-            return result.all()
-
-    mapper.finalize()
-    schema = strawberry.Schema(query=Query)
-
-    building, building2, department1, department2, employee1, employee2 = (
-        create_test_data_with_null_relationship(
-            session,
-            building_department_employee_tables_with_association_proxy_and_null_relationship,
-        )
-    )
-
-    query = query_to_test_association_proxy()
-
-    result = await schema.execute(
-        query,
-        context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)},
-    )
-    session.close()
-
-    assert result.errors is None
-    assert result.data == {
+    return {
         "buildings": [
             {
-                "id": building.id,
-                "name": building.name,
+                "id": building1.id,
+                "name": building1.name,
                 "employees": {
                     "pageInfo": {
                         "hasNextPage": False,

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -13,11 +13,6 @@ from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyMapper
 
 
 @pytest.fixture
-def mapper():
-    return StrawberrySQLAlchemyMapper()
-
-
-@pytest.fixture
 def polymorphic_employee(base):
     class Employee(base):
         __tablename__ = "employee"
@@ -326,8 +321,7 @@ def test_relationships_schema(employee_and_department_tables, mapper):
     @strawberry.type
     class Query:
         @strawberry.field
-        def departments(self) -> Department:
-            ...
+        def departments(self) -> Department: ...
 
     mapper.finalize()
     schema = strawberry.Schema(query=Query)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -146,9 +146,9 @@ def test_convert_all_columns_to_strawberry_type(mapper):
 
 def test_convert_column_to_strawberry_type(mapper):
     int_column = Column(Integer, nullable=False)
-    assert mapper._convert_column_to_strawberry_type(int_column) == int
+    assert mapper._convert_column_to_strawberry_type(int_column) is int
     string_column = Column(String, nullable=False)
-    assert mapper._convert_column_to_strawberry_type(string_column) == str
+    assert mapper._convert_column_to_strawberry_type(string_column) is str
 
 
 def test_convert_json_column_to_strawberry_type(mapper):
@@ -226,9 +226,9 @@ def test_type_simple(employee_table, mapper):
     assert len(mapped_employee_type.__strawberry_definition__.fields) == 2
     employee_type_fields = mapped_employee_type.__strawberry_definition__.fields
     name = next(iter(filter(lambda f: f.name == "name", employee_type_fields)))
-    assert name.type == str
+    assert name.type is str
     id = next(iter(filter(lambda f: f.name == "id", employee_type_fields)))
-    assert id.type == int
+    assert id.type is int
 
 
 def test_interface_and_type_polymorphic(
@@ -302,9 +302,9 @@ def test_type_relationships(employee_and_department_tables, mapper):
     assert len(mapped_employee_type.__strawberry_definition__.fields) == 4
     employee_type_fields = mapped_employee_type.__strawberry_definition__.fields
     name = next(iter(filter(lambda f: f.name == "department_id", employee_type_fields)))
-    assert type(name.type) == StrawberryOptional
+    assert type(name.type) is StrawberryOptional
     id = next(iter(filter(lambda f: f.name == "department", employee_type_fields)))
-    assert type(id.type) == StrawberryOptional
+    assert type(id.type) is StrawberryOptional
 
 
 def test_relationships_schema(employee_and_department_tables, mapper):
@@ -433,7 +433,7 @@ def test_type_with_directives_and_federation(mapper, employee_table, directives)
 
 
 @pytest.mark.parametrize(
-    "use_federation_value, expected_directives",
+    ("use_federation_value", "expected_directives"),
     [(True, []), (False, ())],
 )
 def test_type_with_default_directives(


### PR DESCRIPTION
**Note:** This PR **supersedes** #232 because the original contributor did not allow edits from maintainers, and we needed to add additional tests to proceed with the merge. All credits remain to the original author for the core fix.

Original description:
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

`association_proxy_resolver_for` has a few code blocks that were not updated for the relay changes. Association proxy mapping would fail due do constructors missing either `page_info` or `cursor` args. 

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Documentation

## Issues Fixed or Closed by This PR

* N/a

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).


I haven't added tests as it looks like this code is originally untested.

## Summary by Sourcery

Bug Fixes:
- Fix association proxy mapping failures due to missing `page_info` or `cursor` arguments in constructors.

## Summary by Sourcery

Bug Fixes:
- Ensure association proxy resolvers return valid relay connections, including `page_info` and edge `cursor` details, even for empty results.

## Summary by Sourcery

Fix association proxy resolvers to always return valid relay connections with correct page_info and cursor fields, including for empty results, and add comprehensive tests for association proxy logic.

Bug Fixes:
- Fix association proxy mapping failures by ensuring relay connections include page_info and cursor fields, even for empty results.

Enhancements:
- Improve error messages for unsupported association proxy targets and related exceptions.

Documentation:
- Add release notes describing the patch and its impact.

Tests:
- Add extensive tests for association proxy behavior, including edge cases and nullable relationships.