### PR TITLE
Pagination args

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,167 @@
+Release type: minor
+
+Implement Relay-style cursor pagination for SQLAlchemy relationships by extending the connection resolver and DataLoader to accept pagination arguments, computing pageInfo metadata, and introducing cursor utilities. Add PaginatedLoader to scope DataLoader instances per pagination parameters and update tests to verify pagination behavior.
+
+**New Features**:
+- Support cursor-based pagination (first, after, last, before) on GraphQL relationship fields
+- Introduce PaginatedLoader to manage DataLoader instances per pagination configuration
+
+**Enhancements**:
+- Extend connection resolvers to compute pageInfo fields (hasNextPage, hasPreviousPage, totalCount) and handle forward and backward pagination
+- Add utilities for cursor encoding/decoding and relationship key extraction
+
+**Tests**:
+- Add comprehensive tests for forward and backward pagination scenarios in both synchronous and asynchronous execution contexts
+
+**Examples**:
+
+Get the first three books for a specific author:
+
+```gql
+query {
+  author(id: 1) {
+    id
+    name
+    books(first: 3) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+}
+```
+
+Get all books after a specific book's cursor:
+
+```gql
+query($afterBook: String) {
+  author(id: 1) {
+    id
+    name
+    books(after: $afterBook) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+}
+```
+
+Get the first three books for a specific author after a specific book's cursor:
+
+```gql
+query($afterBook: String) {
+  author(id: 1) {
+    id
+    name
+    books(first: 3, after: $afterBook) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+}
+```
+
+
+Get the last three books for a specific author:
+
+```gql
+query {
+  author(id: 1) {
+    id
+    name
+    books(last: 3) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+}
+```
+
+Get all books before a spcific book's cursor:
+
+```gql
+query($beforeBook: String) {
+  author(id: 1) {
+    id
+    name
+    books(before: $beforeBook) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+}
+```
+
+Get the last three books for a specific author before a spcific book's cursor:
+
+```gql
+query($beforeBook: String) {
+  author(id: 1) {
+    id
+    name
+    books(last: 3, before: $beforeBook) {
+      edges {
+        node {
+          id
+          title
+        }
+      }
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+    }
+  }
+}
+```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -116,7 +116,7 @@ query {
 }
 ```
 
-Get all books before a spcific book's cursor:
+Get all books before a specific book's cursor:
 
 ```gql
 query($beforeBook: String) {
@@ -141,7 +141,7 @@ query($beforeBook: String) {
 }
 ```
 
-Get the last three books for a specific author before a spcific book's cursor:
+Get the last three books for a specific author before a specific book's cursor:
 
 ```gql
 query($beforeBook: String) {

--- a/src/strawberry_sqlalchemy_mapper/loader.py
+++ b/src/strawberry_sqlalchemy_mapper/loader.py
@@ -78,16 +78,17 @@ class PaginatedLoader:
         last: Optional[int] = None,
         before: Optional[str] = None,
     ) -> DataLoader:
-        # Create a cache key from the pagination parameters
-        pagination_key = (
-            ("first", first) if first is not None else None,
-            ("after", after) if after is not None else None,
-            ("last", last) if last is not None else None,
-            ("before", before) if before is not None else None,
-        )
-
         # Filter out None values for the key
-        pagination_key = tuple(item for item in pagination_key if item is not None)
+        pagination_key = tuple(
+            item
+            for item in (
+                ("first", first) if first is not None else None,
+                ("after", after) if after is not None else None,
+                ("last", last) if last is not None else None,
+                ("before", before) if before is not None else None,
+            )
+            if item is not None
+        )
 
         # Create or retrieve a DataLoader for this specific pagination
         # configuration

--- a/src/strawberry_sqlalchemy_mapper/loader.py
+++ b/src/strawberry_sqlalchemy_mapper/loader.py
@@ -36,11 +36,9 @@ class PaginatedLoader:
 
     def __init__(
         self,
-        parent_loader: StrawberrySQLAlchemyLoader,
         relationship: RelationshipProperty,
         load_implementation: Callable,
     ):
-        self.parent_loader: StrawberrySQLAlchemyLoader = parent_loader
         self.relationship: RelationshipProperty = relationship
         self.load_implementation: Callable = load_implementation
         self._loaders: Dict[Tuple, DataLoader] = {}
@@ -290,7 +288,6 @@ class StrawberrySQLAlchemyLoader:
                 return [grouped_keys[key][0] if grouped_keys[key] else None for key in keys]
 
             self._loaders[relationship] = PaginatedLoader(
-                parent_loader=self,
                 relationship=relationship,
                 load_implementation=load_fn,
             )

--- a/src/strawberry_sqlalchemy_mapper/loader.py
+++ b/src/strawberry_sqlalchemy_mapper/loader.py
@@ -22,6 +22,17 @@ from strawberry.dataloader import DataLoader
 from base64 import b64decode
 
 
+def _decode_cursor_index(cursor: str) -> Optional[int]:
+    try:
+        cursor = b64decode(cursor).decode('utf-8')
+        if cursor.startswith('arrayconnection:'):
+            return int(cursor.split(':')[1])
+    except (ValueError, IndexError):
+        # If decoding fails, default to no offset
+        pass
+    return None
+
+
 class StrawberrySQLAlchemyLoader:
     """
     Creates DataLoader instances on-the-fly for SQLAlchemy relationships
@@ -65,7 +76,13 @@ class StrawberrySQLAlchemyLoader:
         except KeyError:
             related_model = relationship.entity.entity
 
-            async def load_fn(keys: List[Tuple], **pagination_args) -> List[Any]:
+            async def load_fn(
+                keys: List[Tuple],
+                first: Optional[int] = None,
+                after: Optional[str] = None,
+                last: Optional[int] = None,
+                before: Optional[str] = None,
+            ) -> List[Any]:
                 query = select(related_model).filter(
                     tuple_(*[remote for _, remote in relationship.local_remote_pairs or []]).in_(
                         keys
@@ -74,27 +91,76 @@ class StrawberrySQLAlchemyLoader:
                 if relationship.order_by:
                     query = query.order_by(*relationship.order_by)
 
-                # Process pagination parameters
-                first = pagination_args.get('first')
-                after = pagination_args.get('after')
+                # Validate input combinations according to Relay spec
+                if first is not None and last is not None:
+                    raise ValueError("Cannot provide both 'first' and 'last'")
+                if first is not None and before is not None:
+                    raise ValueError("Cannot provide both 'first' and 'before'")
+                if last is not None and after is not None:
+                    raise ValueError("Cannot provide both 'last' and 'after'")
 
                 # Extract offset from cursor if provided
                 offset = 0
                 if after:
-                    try:
-                        # Decode cursor format: base64('arrayconnection:{offset}')
-                        cursor = b64decode(after).decode('utf-8')
-                        if cursor.startswith('arrayconnection:'):
-                            offset = int(cursor.split(':')[1]) + 1  # Start after this position
-                    except (ValueError, IndexError):
-                        # If cursor decoding fails, default to no offset
-                        pass
+                    decoded_after = _decode_cursor_index(after)
+                    if decoded_after is not None and decoded_after >= 0:
+                        offset = decoded_after + 1
 
-                # Apply pagination if parameters are provided
-                if offset > 0:
-                    query = query.offset(offset)
-                if first is not None and first >= 0:
-                    query = query.limit(first)
+                # For before/last pagination, we need to handle differently
+                # First, we need to determine the total count and before index
+                before_index: Optional[int] = None
+                if before:
+                    decoded_before = _decode_cursor_index(before)
+                    if decoded_before is not None:
+                        before_index = decoded_before
+
+                if last is not None:
+                    # For just 'last' without 'before', we need the last N items
+                    # Get total count first
+                    count_query = select(func.count()).select_from(
+                        select(related_model).filter(
+                            tuple_(*[remote for _, remote in relationship.local_remote_pairs or []]).in_(
+                                keys
+                            )
+                        ).subquery()
+                    )
+                    sub_result = await self._scalars_all(count_query)
+                    total_count = sub_result[0] if sub_result else 0
+
+                    if before_index is not None:
+                        # If before_index is provided, we need to calculate how many items are before that index
+                        items_before_cursor = min(before_index, total_count)
+
+                        # Calculate the offset to get last N items before the cursor
+                        offset = max(0, items_before_cursor - last)
+                        limit = min(last, items_before_cursor)
+
+                        # Apply the calculated offset and limit
+                        if offset > 0:
+                            query = query.offset(offset)
+                        if limit > 0:
+                            query = query.limit(limit)
+
+                    else:
+
+                        # Calculate offset for last N items
+                        offset = max(0, total_count - last)
+                        if offset > 0:
+                            query = query.offset(offset)
+                        if last > 0:
+                            query = query.limit(last)
+
+                elif before_index is not None:
+                    # If just 'before' without 'last', retrieve all items before the cursor
+                    if before_index > 0:
+                        query = query.limit(before_index)
+
+                else:
+                    # Standard forward pagination with first/after
+                    if offset > 0:
+                        query = query.offset(offset)
+                    if first is not None and first >= 0:
+                        query = query.limit(first)
 
                 rows = await self._scalars_all(query)
 

--- a/src/strawberry_sqlalchemy_mapper/loader.py
+++ b/src/strawberry_sqlalchemy_mapper/loader.py
@@ -130,7 +130,6 @@ class StrawberrySQLAlchemyLoader:
     Creates DataLoader instances on-the-fly for SQLAlchemy relationships
     """
 
-    _loaders: Dict[RelationshipProperty, PaginatedLoader] = {}
 
     def __init__(
         self,
@@ -142,7 +141,7 @@ class StrawberrySQLAlchemyLoader:
             ]
         ] = None,
     ) -> None:
-        self._loaders = {}
+        self._loaders: Dict[RelationshipProperty, PaginatedLoader] = {}
         self._bind = bind
         self._async_bind_factory = async_bind_factory
         self._logger = logging.getLogger("strawberry_sqlalchemy_mapper")

--- a/src/strawberry_sqlalchemy_mapper/loader.py
+++ b/src/strawberry_sqlalchemy_mapper/loader.py
@@ -154,7 +154,7 @@ class StrawberrySQLAlchemyLoader:
             .subquery(),
         )
         sub_result = await self._scalar_one(count_query)
-        return cast(int, sub_result or 0)
+        return cast("int", sub_result or 0)
 
     async def get_relationship_record_count_for_key(
         self,

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -602,7 +602,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
 
         if relationship.uselist:
 
-            async def resolve(
+            async def resolve_list(
                 self,
                 info: Info,
                 first: Optional[int] = None,
@@ -635,8 +635,8 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                     )
                 return related_objects
 
-            setattr(resolve, _IS_GENERATED_RESOLVER_KEY, True)
-            return resolve
+            setattr(resolve_list, _IS_GENERATED_RESOLVER_KEY, True)
+            return resolve_list
 
         else:
 

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -133,9 +133,9 @@ class StrawberrySQLAlchemyLazy(LazyType):
 def _get_loader_from_info(info: Info) -> StrawberrySQLAlchemyLoader:
     """Extracts the sqlalchemy loader from info."""
     if isinstance(info.context, dict):
-        return cast(StrawberrySQLAlchemyLoader, info.context["sqlalchemy_loader"])
+        return cast("StrawberrySQLAlchemyLoader", info.context["sqlalchemy_loader"])
     else:
-        return cast(StrawberrySQLAlchemyLoader, info.context.sqlalchemy_loader)
+        return cast("StrawberrySQLAlchemyLoader", info.context.sqlalchemy_loader)
 
 
 def _get_relationship_key(model: object, relationship: RelationshipProperty) -> Tuple[str, ...]:

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -655,9 +655,8 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                     related_objects = await loader.loader_for(relationship).load(
                         relationship_key,
                     )
-                setattr(resolve, _IS_GENERATED_RESOLVER_KEY, True)
                 return related_objects
-
+            setattr(resolve, _IS_GENERATED_RESOLVER_KEY, True)
             return resolve
 
     def connection_resolver_for(

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -656,6 +656,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
                         relationship_key,
                     )
                 return related_objects
+
             setattr(resolve, _IS_GENERATED_RESOLVER_KEY, True)
             return resolve
 

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -132,11 +132,7 @@ class StrawberrySQLAlchemyLazy(LazyType):
 def _get_relationship_key(model: object, relationship: RelationshipProperty) -> Tuple[str, ...]:
     """Return relationship key for data loader."""
     return tuple(
-        [
-            getattr(model, local.key)
-            for local, _ in relationship.local_remote_pairs or []
-            if local.key
-        ],
+        getattr(model, local.key) for local, _ in relationship.local_remote_pairs or [] if local.key
     )
 
 

--- a/src/strawberry_sqlalchemy_mapper/pagination_cursor_utils.py
+++ b/src/strawberry_sqlalchemy_mapper/pagination_cursor_utils.py
@@ -2,16 +2,18 @@ from typing import Optional
 
 from strawberry import relay
 
+
 def decode_cursor_index(cursor: str) -> Optional[int]:
     """Convert an array connection cursor into the relevant row index."""
     try:
         start, str_index = relay.from_base64(cursor)
-        if start == 'arrayconnection':
+        if start == "arrayconnection":
             return int(str_index)
     except (ValueError, IndexError):
         # If decoding fails, default to no offset
         pass
     return None
+
 
 def encode_cursor_index(cursor_index: int) -> str:
     """Convert an array connection cursor into the relevant row index."""

--- a/src/strawberry_sqlalchemy_mapper/pagination_cursor_utils.py
+++ b/src/strawberry_sqlalchemy_mapper/pagination_cursor_utils.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+from strawberry import relay
+
+def decode_cursor_index(cursor: str) -> Optional[int]:
+    """Convert an array connection cursor into the relevant row index."""
+    try:
+        start, str_index = relay.from_base64(cursor)
+        if start == 'arrayconnection':
+            return int(str_index)
+    except (ValueError, IndexError):
+        # If decoding fails, default to no offset
+        pass
+    return None
+
+def encode_cursor_index(cursor_index: int) -> str:
+    """Convert an array connection cursor into the relevant row index."""
+    return relay.to_base64("arrayconnection", cursor_index)

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -462,7 +462,7 @@ def get_schema_should_not_raise_UnsupportedAssociation_if_excluded_expected_shem
     type Query {
       departments: Department!
     }
-    '''
+    '''  # noqa: E501 - long lines needed for exact string matches
 
 
 def get_test_relationships_schema_with_association_proxy_expected_schema():
@@ -535,7 +535,7 @@ type PageInfo {
 type Query {
   buildings: Building!
 }
-    '''
+    '''  # noqa: E501 - long lines needed for exact string matches
 
 
 def create_test_data(

--- a/tests/test_association_proxy.py
+++ b/tests/test_association_proxy.py
@@ -420,7 +420,7 @@ def get_schema_should_not_raise_UnsupportedAssociation_if_excluded_expected_shem
     type Department {
       id: Int!
       name: String!
-      employees: EmployeeConnection!
+      employees(first: Int = null, after: String = null, last: Int = null, before: String = null): EmployeeConnection!
     }
 
     type Employee {
@@ -470,7 +470,7 @@ def get_test_relationships_schema_with_association_proxy_expected_schema():
 type Building {
   id: Int!
   name: String!
-  departments: DepartmentConnection!
+  departments(first: Int = null, after: String = null, last: Int = null, before: String = null): DepartmentConnection!
   employees: EmployeeConnection!
 }
 
@@ -479,7 +479,7 @@ type Department {
   name: String!
   buildingId: Int
   building: Building
-  employees: EmployeeConnection!
+  employees(first: Int = null, after: String = null, last: Int = null, before: String = null): EmployeeConnection!
 }
 
 type DepartmentConnection {

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -84,7 +84,8 @@ async def test_loader_for(engine, base, sessionmaker, many_to_one_tables):
         e2.department = d1
         session.commit()
         base_loader = StrawberrySQLAlchemyLoader(bind=session)
-        loader = base_loader.loader_for(Employee.department.property)
+        paginated_loader = base_loader.loader_for(Employee.department.property)
+        loader = paginated_loader.loader_for()
         assert loader.max_batch_size is None
         assert loader.cache is True
         assert not loader.cache_map.cache_map
@@ -97,7 +98,8 @@ async def test_loader_for(engine, base, sessionmaker, many_to_one_tables):
         department = await loader.load(key)
         assert department.name == "d2"
 
-        loader = base_loader.loader_for(Department.employees.property)
+        paginated_loader = base_loader.loader_for(Department.employees.property)
+        loader = paginated_loader.loader_for()
 
         employees = await loader.load((d2.id,))
         assert {e.name for e in employees} == {"e1"}
@@ -130,12 +132,12 @@ async def test_loader_with_async_session(
             getattr(e1, local.key) for local, _ in Employee.department.property.local_remote_pairs
         )
     base_loader = StrawberrySQLAlchemyLoader(async_bind_factory=async_sessionmaker)
-    loader = base_loader.loader_for(Employee.department.property)
+    loader = base_loader.loader_for(Employee.department.property).loader_for()
 
     department = await loader.load(department_loader_key)
     assert department.name == "d2"
 
-    loader = base_loader.loader_for(Department.employees.property)
+    loader = base_loader.loader_for(Department.employees.property).loader_for()
     employees = await loader.load((d2_id,))
     assert {e.name for e in employees} == {"e1"}
 
@@ -163,7 +165,7 @@ async def test_loader_for_secondary(engine, base, sessionmaker, secondary_tables
         session.commit()
 
         base_loader = StrawberrySQLAlchemyLoader(bind=session)
-        loader = base_loader.loader_for(Employee.departments.property)
+        loader = base_loader.loader_for(Employee.departments.property).loader_for()
 
         key = tuple(
             [

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -202,22 +202,34 @@ async def test_loader_for_pagination_valid(engine, base, sessionmaker, many_to_o
         session.commit()
         base_loader = StrawberrySQLAlchemyLoader(bind=session)
         paginated_loader = base_loader.loader_for(Department.employees.property)
+
         first_loader = paginated_loader.loader_for(first=2)
+        assert not (await first_loader.load((d_empty.id,))), "d_empty returns no results"
         employees = await first_loader.load((d1.id,))
         assert {e.name for e in employees} == {"e1", "e2"}
+
         last_loader = paginated_loader.loader_for(last=2)
+        assert not (await last_loader.load((d_empty.id,))), "d_empty returns no results"
         employees = await last_loader.load((d1.id,))
         assert {e.name for e in employees} == {"e3", "e4"}
+
         before_loader = paginated_loader.loader_for(before=encode_cursor_index(3))
+        assert not (await before_loader.load((d_empty.id,))), "d_empty returns no results"
         employees = await before_loader.load((d1.id,))
         assert {e.name for e in employees} == {"e1", "e2", "e3"}
+
         after_loader = paginated_loader.loader_for(after=encode_cursor_index(0))
+        assert not (await after_loader.load((d_empty.id,))), "d_empty returns no results"
         employees = await after_loader.load((d1.id,))
         assert {e.name for e in employees} == {"e2", "e3", "e4"}
+
         first_after_loader = paginated_loader.loader_for(first=2, after=encode_cursor_index(0))
+        assert not (await first_after_loader.load((d_empty.id,))), "d_empty returns no results"
         employees = await first_after_loader.load((d1.id,))
         assert {e.name for e in employees} == {"e2", "e3"}
+
         last_before_loader = paginated_loader.loader_for(last=2, before=encode_cursor_index(2))
+        assert not (await last_before_loader.load((d_empty.id,))), "d_empty returns no results"
         employees = await last_before_loader.load((d1.id,))
         assert {e.name for e in employees} == {"e1", "e2"}
 
@@ -244,12 +256,21 @@ async def test_loader_for_pagination_invalid(engine, base, sessionmaker, many_to
         session.commit()
         base_loader = StrawberrySQLAlchemyLoader(bind=session)
         paginated_loader = base_loader.loader_for(Department.employees.property)
+
         first_last_loader = paginated_loader.loader_for(first=2, last=3)
         with pytest.raises(ValueError, match="Cannot provide"):
             await first_last_loader.load((d1.id,))
+        with pytest.raises(ValueError, match="Cannot provide"):
+            await first_last_loader.load((d_empty.id,))
+
         first_before_loader = paginated_loader.loader_for(first=2, before=encode_cursor_index(3))
         with pytest.raises(ValueError, match="Cannot provide"):
             await first_before_loader.load((d1.id,))
+        with pytest.raises(ValueError, match="Cannot provide"):
+            await first_before_loader.load((d_empty.id,))
+
         last_after_loader = paginated_loader.loader_for(last=2, after=encode_cursor_index(0))
         with pytest.raises(ValueError, match="Cannot provide"):
             await last_after_loader.load((d1.id,))
+        with pytest.raises(ValueError, match="Cannot provide"):
+            await last_after_loader.load((d_empty.id,))

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -361,7 +361,7 @@ def test_relationships_schema(employee_and_department_tables, mapper):
     type Query {
       departments: Department!
     }
-    '''
+    '''  # noqa: E501 - long lines needed for exact string matches
     assert str(schema) == textwrap.dedent(expected).strip()
 
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -319,7 +319,7 @@ def test_relationships_schema(employee_and_department_tables, mapper):
     type Department {
       id: Int!
       name: String!
-      employees: EmployeeConnection!
+      employees(first: Int = null, after: String = null, last: Int = null, before: String = null): EmployeeConnection!
     }
 
     type Employee {

--- a/tests/test_mapper_inheritance.py
+++ b/tests/test_mapper_inheritance.py
@@ -61,8 +61,8 @@ type ApiB {
   relationshipB: ModelB
   parentId: String
   parent: ModelB
-  relatedA: ModelAConnection!
-  children: ModelBConnection!
+  relatedA(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelAConnection!
+  children(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelBConnection!
 }
 
 type ModelA {
@@ -89,8 +89,8 @@ type ModelB {
   id: String!
   parentId: String
   parent: ModelB
-  relatedA: ModelAConnection!
-  children: ModelBConnection!
+  relatedA(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelAConnection!
+  children(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelBConnection!
 }
 
 type ModelBConnection {
@@ -162,8 +162,8 @@ type ApiB {
   relationshipB: ModelB
   parentId: String
   parent: ModelB
-  relatedA: ModelAConnection!
-  children: ModelBConnection!
+  relatedA(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelAConnection!
+  children(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelBConnection!
 }
 
 type ModelA {
@@ -190,8 +190,8 @@ type ModelB {
   id: String!
   parentId: String
   parent: ModelB
-  relatedA: ModelAConnection!
-  children: ModelBConnection!
+  relatedA(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelAConnection!
+  children(first: Int = null, after: String = null, last: Int = null, before: String = null): ModelBConnection!
 }
 
 type ModelBConnection {

--- a/tests/test_mapper_inheritance.py
+++ b/tests/test_mapper_inheritance.py
@@ -126,7 +126,7 @@ type Query {
   apisb: ApiB!
 }
 
-    '''
+    '''  # noqa: E501 - long lines needed for exact string matches
 
 
 def test_types_with_inheritance_should_respect_exclude_fields(
@@ -227,7 +227,7 @@ type Query {
   apisb: ApiB!
 }
 
-    '''
+    '''  # noqa: E501 - long lines needed for exact string matches
 
 
 @pytest.fixture

--- a/tests/test_relationship_pagination.py
+++ b/tests/test_relationship_pagination.py
@@ -1,4 +1,5 @@
 from typing import Any, List
+import asyncio
 import pytest
 import strawberry
 from sqlalchemy import Column, ForeignKey, Integer, String, select
@@ -97,14 +98,15 @@ def test_relationship_pagination(
         }
         """
 
-        result = schema.execute_sync(
+        # TODO: get execute_sync to work
+        result = asyncio.run(schema.execute(
             query,
             context_value={
                 "sqlalchemy_loader": StrawberrySQLAlchemyLoader(
                     bind=session,
                 ),
             },
-        )
+        ))
         assert result.errors is None
 
         # Check pagination results
@@ -138,11 +140,11 @@ def test_relationship_pagination(
         }
         """
 
-        result = schema.execute_sync(
+        result = asyncio.run(schema.execute(
             query,
             variable_values={"after": end_cursor},
             context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)}
-        )
+        ))
         assert result.errors is None
 
         # Check next page results
@@ -350,14 +352,14 @@ def test_relationship_pagination_last(
         }
         """
 
-        result = schema.execute_sync(
+        result = asyncio.run(schema.execute(
             query,
             context_value={
                 "sqlalchemy_loader": StrawberrySQLAlchemyLoader(
                     bind=session
                 ),
             },
-        )
+        ))
         assert result.errors is None
 
         # Check backward pagination results
@@ -393,11 +395,11 @@ def test_relationship_pagination_last(
         }
         """
 
-        result = schema.execute_sync(
+        result = asyncio.run(schema.execute(
             query,
             variable_values={"before": start_cursor},
             context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)}
-        )
+        ))
         assert result.errors is None
 
         # Check previous page results

--- a/tests/test_relationship_pagination.py
+++ b/tests/test_relationship_pagination.py
@@ -137,6 +137,7 @@ def async_session_schema(
     mapper.finalize()
     return strawberry.Schema(query=Query)
 
+
 @pytest.fixture
 def general_query() -> str:
     """General purpose query."""
@@ -202,11 +203,7 @@ def test_relationship_pagination(
     result = asyncio.run(
         sync_session_schema.execute(
             general_query,
-            variable_values={
-                "authorId": sync_author.id,
-                "first": 4,
-                "after": end_cursor
-            },
+            variable_values={"authorId": sync_author.id, "first": 4, "after": end_cursor},
             context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=sync_session)},
         )
     )
@@ -271,7 +268,8 @@ def test_relationship_pagination_last(
         sync_session_schema.execute(
             general_query,
             variable_values={
-                "authorId": sync_author.id, "last": 3,
+                "authorId": sync_author.id,
+                "last": 3,
             },
             context_value={
                 "sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=sync_session),
@@ -320,7 +318,7 @@ async def test_relationship_pagination_last_async(
     loader = StrawberrySQLAlchemyLoader(async_bind_factory=lambda: async_session)
     result = await async_session_schema.execute(
         general_query,
-        variable_values={"authorId": async_author.id, "last": 3,},
+        variable_values={"authorId": async_author.id, "last": 3},
         context_value={"sqlalchemy_loader": loader},
     )
     assert result.errors is None
@@ -336,7 +334,6 @@ async def test_relationship_pagination_last_async(
     # Get the start cursor for the before parameter
     start_cursor = books_connection["pageInfo"]["startCursor"]
 
-
     result = await async_session_schema.execute(
         general_query,
         variable_values={"authorId": async_author.id, "last": 4, "before": start_cursor},
@@ -351,12 +348,13 @@ async def test_relationship_pagination_last_async(
     # If we have less than 7 books before the cursor, we should have previous page
     assert books_connection["pageInfo"]["hasPreviousPage"] is True
 
+
 @pytest.mark.asyncio
 async def test_relationship_pagination_invalid_args(
     async_session: AsyncSession,
     async_session_schema: strawberry.Schema,
     async_author,
-    general_query
+    general_query,
 ):
     """Test invalid pagination args."""
     loader = StrawberrySQLAlchemyLoader(async_bind_factory=lambda: async_session)
@@ -378,18 +376,16 @@ async def test_relationship_pagination_invalid_args(
 
     result = await async_session_schema.execute(
         general_query,
-        variable_values={"authorId": async_author.id, "first": 2, "before": end_cursor}
+        variable_values={"authorId": async_author.id, "first": 2, "before": end_cursor},
     )
     assert result.errors is not None, "First and before should cause error"
 
     result = await async_session_schema.execute(
-        general_query,
-        variable_values={"authorId": async_author.id, "last": 2, "after": end_cursor}
+        general_query, variable_values={"authorId": async_author.id, "last": 2, "after": end_cursor}
     )
     assert result.errors is not None, "Last and after should cause error"
 
     result = await async_session_schema.execute(
-        general_query,
-        variable_values={"authorId": async_author.id, "first": 2, "last": 3}
+        general_query, variable_values={"authorId": async_author.id, "first": 2, "last": 3}
     )
     assert result.errors is not None, "First and last should cause error"

--- a/tests/test_relationship_pagination.py
+++ b/tests/test_relationship_pagination.py
@@ -1,0 +1,268 @@
+from typing import Any, List
+import pytest
+import strawberry
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio.engine import AsyncEngine
+from sqlalchemy.orm import relationship, sessionmaker
+from strawberry import relay
+from strawberry.types import Info
+from strawberry_sqlalchemy_mapper import StrawberrySQLAlchemyLoader, StrawberrySQLAlchemyMapper
+
+
+@pytest.fixture
+def author_book_tables(base: Any):
+    class Author(base):
+        __tablename__ = "author"
+        id = Column(Integer, autoincrement=True, primary_key=True)
+        name = Column(String(50), nullable=False)
+        books = relationship("Book", back_populates="author")
+
+    class Book(base):
+        __tablename__ = "book"
+        id = Column(Integer, autoincrement=True, primary_key=True)
+        title = Column(String(100), nullable=False)
+        author_id = Column(Integer, ForeignKey("author.id"), nullable=False)
+        author = relationship("Author", back_populates="books")
+
+    return Author, Book
+
+
+def test_relationship_pagination(
+    base: Any, engine: Engine, sessionmaker: sessionmaker, author_book_tables
+):
+    """Test pagination on relationship fields using first and after parameters."""
+    base.metadata.create_all(engine)
+    Author, Book = author_book_tables
+
+    mapper = StrawberrySQLAlchemyMapper()
+
+    @mapper.type(Author)
+    class AuthorType(relay.Node):
+        id: relay.NodeID[int]
+        name: str
+
+    @mapper.type(Book)
+    class BookType(relay.Node):
+        id: relay.NodeID[int]
+        title: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def author(self, info: Info, id: int) -> AuthorType:
+            with sessionmaker() as session:
+                return session.query(Author).filter(Author.id == id).first()
+
+    schema = strawberry.Schema(query=Query)
+
+    with sessionmaker() as session:
+        # Create test data
+        author = Author(name="Test Author")
+        session.add(author)
+        session.flush()  # To get the author ID
+
+        # Create 10 books for pagination testing
+        for i in range(10):
+            book = Book(title=f"Book {i+1}", author_id=author.id)
+            session.add(book)
+
+        session.commit()
+
+        # Query for first 3 books
+        query = """
+        query {
+          author(id: 1) {
+            id
+            name
+            books(first: 3) {
+              edges {
+                node {
+                  id
+                  title
+                }
+              }
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+            }
+          }
+        }
+        """
+
+        result = schema.execute_sync(query, context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)})
+        assert result.errors is None
+
+        # Check pagination results
+        books_connection = result.data["author"]["books"]
+        assert len(books_connection["edges"]) == 3
+        assert books_connection["pageInfo"]["hasNextPage"] is True
+        assert books_connection["pageInfo"]["hasPreviousPage"] is False
+
+        # Store the end cursor for the next pagination query
+        end_cursor = books_connection["pageInfo"]["endCursor"]
+
+        # Query for next 4 books after the cursor
+        query = """
+        query($after: String!) {
+          author(id: 1) {
+            books(first: 4, after: $after) {
+              edges {
+                node {
+                  id
+                  title
+                }
+              }
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+            }
+          }
+        }
+        """
+
+        result = schema.execute_sync(
+            query,
+            variable_values={"after": end_cursor},
+            context_value={"sqlalchemy_loader": StrawberrySQLAlchemyLoader(bind=session)}
+        )
+        assert result.errors is None
+
+        # Check next page results
+        books_connection = result.data["author"]["books"]
+        assert len(books_connection["edges"]) == 4
+        assert books_connection["pageInfo"]["hasNextPage"] is True
+        assert books_connection["pageInfo"]["hasPreviousPage"] is True
+
+
+@pytest.mark.asyncio
+async def test_relationship_pagination_async(
+    base: Any, async_engine: AsyncEngine, async_sessionmaker, author_book_tables
+):
+    """Test pagination on relationship fields using async execution."""
+    async with async_engine.begin() as conn:
+        await conn.run_sync(base.metadata.create_all)
+
+    Author, Book = author_book_tables
+    mapper = StrawberrySQLAlchemyMapper()
+
+    @mapper.type(Author)
+    class AuthorType(relay.Node):
+        id: relay.NodeID[int]
+        name: str
+
+    @mapper.type(Book)
+    class BookType(relay.Node):
+        id: relay.NodeID[int]
+        title: str
+
+    @strawberry.type
+    class Query:
+        @strawberry.field
+        def author(self, info: Info, id: int) -> AuthorType:
+            session = info.context["session"]
+            return session.get(Author, id)
+
+    schema = strawberry.Schema(query=Query)
+
+    async with async_sessionmaker(expire_on_commit=False) as session:
+        # Create test data
+        author = Author(name="Test Author")
+        session.add(author)
+        await session.flush()  # To get the author ID
+
+        # Create 10 books for pagination testing
+        for i in range(10):
+            book = Book(title=f"Book {i+1}", author_id=author.id)
+            session.add(book)
+
+        await session.commit()
+        author_id = author.id
+
+    async with async_sessionmaker(expire_on_commit=False) as session:
+        # Query for first 3 books
+        query = """
+        query {
+          author(id: 1) {
+            id
+            name
+            books(first: 3) {
+              edges {
+                node {
+                  id
+                  title
+                }
+              }
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+            }
+          }
+        }
+        """
+
+        loader = StrawberrySQLAlchemyLoader(async_bind_factory=lambda: session)
+        result = await schema.execute(
+            query,
+            context_value={
+                "sqlalchemy_loader": loader,
+                "session": session
+            }
+        )
+        assert result.errors is None
+
+        # Check pagination results
+        books_connection = result.data["author"]["books"]
+        assert len(books_connection["edges"]) == 3
+        assert books_connection["pageInfo"]["hasNextPage"] is True
+        assert books_connection["pageInfo"]["hasPreviousPage"] is False
+
+        # Store the end cursor for the next pagination query
+        end_cursor = books_connection["pageInfo"]["endCursor"]
+
+        # Query for next 4 books after the cursor
+        query = """
+        query($after: String!) {
+          author(id: 1) {
+            books(first: 4, after: $after) {
+              edges {
+                node {
+                  id
+                  title
+                }
+              }
+              pageInfo {
+                hasNextPage
+                hasPreviousPage
+                startCursor
+                endCursor
+              }
+            }
+          }
+        }
+        """
+
+        result = await schema.execute(
+            query,
+            variable_values={"after": end_cursor},
+            context_value={
+                "sqlalchemy_loader": loader,
+                "session": session
+            }
+        )
+        assert result.errors is None
+
+        # Check next page results
+        books_connection = result.data["author"]["books"]
+        assert len(books_connection["edges"]) == 4
+        assert books_connection["pageInfo"]["hasNextPage"] is True
+        assert books_connection["pageInfo"]["hasPreviousPage"] is True

--- a/tests/test_relationship_pagination.py
+++ b/tests/test_relationship_pagination.py
@@ -59,7 +59,7 @@ def sync_author(
 
     # Create 10 books for pagination testing
     for i in range(10):
-        book = BookModel(title=f"Book {i+1}", author_id=author.id)
+        book = BookModel(title=f"Book {i + 1}", author_id=author.id)
         sync_session.add(book)
 
     sync_session.commit()
@@ -83,7 +83,7 @@ async def async_author(
 
     # Create 10 books for pagination testing
     for i in range(10):
-        book = BookModel(title=f"Book {i+1}", author_id=author.id)
+        book = BookModel(title=f"Book {i + 1}", author_id=author.id)
         async_session.add(book)
 
     await async_session.commit()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

I'm currently looking into pagination arguments in this project. It's working here, but one thing to call out are the synchronous tests -- I wasn't able to get `schema.run_sync` to run appropriately so I wrapped the synchronous tests in `asyncio.run` for now. There might be a deeper bug to look into here. EDIT: I've tested this on the current main branch with comparable tests without pagination, and `.execute_sync` fails on the main branch too.

Hoping for some initial thoughts before I go deeper. Let me know what you think!

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Closes https://github.com/strawberry-graphql/strawberry-sqlalchemy/issues/236

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).

## Summary by Sourcery

Implement Relay-style cursor pagination for SQLAlchemy relationships by extending the connection resolver and DataLoader to accept pagination arguments, computing pageInfo metadata, and introducing cursor utilities. Add PaginatedLoader to scope DataLoader instances per pagination parameters and update tests to verify pagination behavior.

New Features:
- Support cursor-based pagination (first, after, last, before) on GraphQL relationship fields
- Introduce PaginatedLoader to manage DataLoader instances per pagination configuration

Enhancements:
- Extend connection resolvers to compute pageInfo fields (hasNextPage, hasPreviousPage, totalCount) and handle forward and backward pagination
- Add utilities for cursor encoding/decoding and relationship key extraction

Tests:
- Add comprehensive tests for forward and backward pagination scenarios in both synchronous and asynchronous execution contexts

## Summary by Sourcery

Add Relay-style cursor pagination support to Strawberry SQLAlchemy mapper by extending resolvers and data loaders to accept and handle first, after, last, and before arguments

New Features:
- Support cursor-based pagination (first, after, last, before) on GraphQL connection fields for SQLAlchemy relationships
- Introduce PaginatedLoader to scope DataLoader instances per pagination configuration

Enhancements:
- Extend connection and relationship resolvers to propagate pagination parameters and compute pageInfo (hasNextPage, hasPreviousPage, totalCount)
- Implement offset and limit logic in loader implementation, including validation of invalid argument combinations
- Add utilities for encoding and decoding array connection cursors

Documentation:
- Add RELEASE.md with release notes and GraphQL pagination examples

Tests:
- Add unit tests for valid and invalid pagination scenarios in DataLoader
- Update schema generation tests to include pagination arguments on connection fields
- Add integration tests for forward and backward pagination in synchronous and asynchronous execution contexts