### PR TITLE
Option to always "use_list" and not make relay Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,25 @@ class ApiB(ApiA):
     # "extra_field" will be overridden and will be a float now instead of the String type declared in ModelB:
     extra_field: float = strawberry.field(name="extraField")
 ```
+
+### Relay connections
+
+By default, StrawberrySQLAlchemyMapper() will create [Relay connections](https://relay.dev/graphql/connections.htm) for relationships to lists. If instead you want these relationships to present as plain lists, you have two options:
+
+1. Declare `__use_list__` in your models, for example:
+
+```python
+@strawberry_sqlalchemy_mapper.type(models.Department)
+class Department:
+    __use_list__ = ["employees"]
+```
+
+2. Alternatively, you can disable relay style connections for all models via the `always_use_list` constructor parameter:
+
+```python
+strawberry_sqlalchemy_mapper = StrawberrySQLAlchemyMapper(always_use_list=True)
+```
+
 ## Limitations
 
 ### Supported Types

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 Release type: minor
 
-Added a new optional constructor parameter to always use lists instead of relay Connectors for relationships. Defaults to False, maintaining current functionality. If set to True, all relationships will be handled as lists.
+Added a new optional constructor parameter to always use lists instead of relay Connections for relationships. Defaults to False, maintaining current functionality. If set to True, all relationships will be handled as lists.
 
 Example:
 mapper = StrawberrySQLAlchemyMapper(always_use_list=True)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+Release type: minor
+
+Added a new optional constructor parameter to always use lists instead of relay Connectors for relationships. Defaults to False, maintaining current functionality. If set to True, all relationships will be handled as lists.
+
+Example:
+mapper = StrawberrySQLAlchemyMapper(always_use_list=True)

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -675,7 +675,7 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
         passed from the GraphQL query to the database query.
         """
         relationship_resolver = self.relationship_resolver_for(relationship)
-        if relationship.uselist and not (use_list or self.always_use_list):
+        if relationship.uselist and not use_list and not self.always_use_list:
             return self.make_connection_wrapper_resolver(
                 relationship_resolver,
                 relationship,

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -255,14 +255,14 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
         extra_sqlalchemy_type_to_strawberry_type_map: Optional[
             Mapping[Type[TypeEngine], Type[Any]]
         ] = None,
-        always_use_list: Optional[bool] = False,
+        always_use_list: bool = False,
     ) -> None:
         if model_to_type_name is None:
             model_to_type_name = self._default_model_to_type_name
         self.model_to_type_name = model_to_type_name
         if model_to_interface_name is None:
             model_to_interface_name = self._default_model_to_interface_name
-        self.always_use_list = always_use_list or False
+        self.always_use_list = always_use_list
         self.model_to_interface_name = model_to_interface_name
         self.sqlalchemy_type_to_strawberry_type_map = (
             self._default_sqlalchemy_type_to_strawberry_type_map.copy()

--- a/src/strawberry_sqlalchemy_mapper/mapper.py
+++ b/src/strawberry_sqlalchemy_mapper/mapper.py
@@ -252,10 +252,10 @@ class StrawberrySQLAlchemyMapper(Generic[BaseModelType]):
         self,
         model_to_type_name: Optional[Callable[[Type[BaseModelType]], str]] = None,
         model_to_interface_name: Optional[Callable[[Type[BaseModelType]], str]] = None,
-        always_use_list: Optional[bool] = None,
         extra_sqlalchemy_type_to_strawberry_type_map: Optional[
             Mapping[Type[TypeEngine], Type[Any]]
         ] = None,
+        always_use_list: Optional[bool] = False,
     ) -> None:
         if model_to_type_name is None:
             model_to_type_name = self._default_model_to_type_name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,3 +118,8 @@ def base():
 @pytest.fixture
 def mapper():
     return StrawberrySQLAlchemyMapper()
+
+
+@pytest.fixture
+def mapper_always_use_list():
+    return StrawberrySQLAlchemyMapper(always_use_list=True)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -303,6 +303,43 @@ def test_always_use_list(employee_and_department_tables, mapper_always_use_list)
     assert isinstance(name.type, StrawberryList) is True
 
 
+def test_always_use_list_with_mixed_relationships(
+    employee_and_department_tables, mapper_always_use_list
+):
+    Employee, Department = employee_and_department_tables
+
+    @mapper_always_use_list.type(Employee)
+    class EmployeeType:
+        pass
+
+    @mapper_always_use_list.type(Department)
+    class DepartmentType:
+        pass
+
+    mapper_always_use_list.finalize()
+    additional_types = list(mapper_always_use_list.mapped_types.values())
+    assert len(additional_types) == 2
+    mapped_employee_type = additional_types[0]
+    assert mapped_employee_type.__name__ == "EmployeeType"
+    mapped_department_type = additional_types[1]
+    assert mapped_department_type.__name__ == "DepartmentType"
+
+    department_type_fields = mapped_department_type.__strawberry_definition__.fields
+    employees_field = next((f for f in department_type_fields if f.name == "employees"), None)
+    assert employees_field is not None
+    # List relationship should be StrawberryList with always_use_list=True
+    assert isinstance(
+        employees_field.type, StrawberryList
+    )
+
+    employee_type_fields = mapped_employee_type.__strawberry_definition__.fields
+    department_field = next((f for f in employee_type_fields if f.name == "department"), None)
+    assert department_field is not None
+    # Single relationship should remain as Optional, not converted to a list
+    assert not isinstance(department_field.type, StrawberryList)
+    assert isinstance(department_field.type, StrawberryOptional)
+
+
 def test_type_relationships(employee_and_department_tables, mapper):
     Employee, _ = employee_and_department_tables
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -320,9 +320,9 @@ def test_always_use_list_with_mixed_relationships(
     additional_types = list(mapper_always_use_list.mapped_types.values())
     assert len(additional_types) == 2
     mapped_employee_type = additional_types[0]
-    assert mapped_employee_type.__name__ == "EmployeeType"
+    assert mapped_employee_type.__name__ == "Employee"
     mapped_department_type = additional_types[1]
-    assert mapped_department_type.__name__ == "DepartmentType"
+    assert mapped_department_type.__name__ == "Department"
 
     department_type_fields = mapped_department_type.__strawberry_definition__.fields
     employees_field = next((f for f in department_type_fields if f.name == "employees"), None)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -276,6 +276,33 @@ def test_use_list(employee_and_department_tables, mapper):
     assert isinstance(name.type, StrawberryList) is True
 
 
+def test_always_use_list(employee_and_department_tables, mapper_always_use_list):
+    Employee, Department = employee_and_department_tables
+
+    @mapper_always_use_list.type(Employee)
+    class Employee:
+        pass
+
+    @mapper_always_use_list.type(Department)
+    class Department:
+        pass
+
+    mapper_always_use_list.finalize()
+    additional_types = list(mapper_always_use_list.mapped_types.values())
+    assert len(additional_types) == 2
+    mapped_employee_type = additional_types[0]
+    assert mapped_employee_type.__name__ == "Employee"
+    mapped_department_type = additional_types[1]
+    assert mapped_department_type.__name__ == "Department"
+    assert len(mapped_department_type.__strawberry_definition__.fields) == 3
+    department_type_fields = mapped_department_type.__strawberry_definition__.fields
+
+    name = next((field for field in department_type_fields if field.name == "employees"), None)
+    assert name is not None
+    assert isinstance(name.type, StrawberryOptional) is False
+    assert isinstance(name.type, StrawberryList) is True
+
+
 def test_type_relationships(employee_and_department_tables, mapper):
     Employee, _ = employee_and_department_tables
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -309,11 +309,11 @@ def test_always_use_list_with_mixed_relationships(
     Employee, Department = employee_and_department_tables
 
     @mapper_always_use_list.type(Employee)
-    class EmployeeType:
+    class Employee:
         pass
 
     @mapper_always_use_list.type(Department)
-    class DepartmentType:
+    class Department:
         pass
 
     mapper_always_use_list.finalize()
@@ -328,9 +328,7 @@ def test_always_use_list_with_mixed_relationships(
     employees_field = next((f for f in department_type_fields if f.name == "employees"), None)
     assert employees_field is not None
     # List relationship should be StrawberryList with always_use_list=True
-    assert isinstance(
-        employees_field.type, StrawberryList
-    )
+    assert isinstance(employees_field.type, StrawberryList)
 
     employee_type_fields = mapped_employee_type.__strawberry_definition__.fields
     department_field = next((f for f in employee_type_fields if f.name == "department"), None)


### PR DESCRIPTION
## Description

I added an optional constructor parameter to always use lists for relationships and not make relay Connections. This way users who don't use Connections don't have to add `__use_list__` to every model.

## Types of Changes

<!--- What types of changes does your pull request introduce? Put an `x` in all the boxes that apply. -->
- [x] Core
- [ ] Bugfix
- [x] New feature
- [ ] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* not fixed, but related to https://github.com/strawberry-graphql/strawberry-sqlalchemy/issues/7

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes. (Couldn't get `tox` to run... will continue to look into this)
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage). 
(I'm using it in my project.)

## Summary by Sourcery

Add optional always_use_list parameter to StrawberrySQLAlchemyMapper to default relationship fields to lists and bypass Relay Connection creation.

New Features:
- Introduce always_use_list constructor parameter to always generate lists for relationships instead of Relay Connections

Enhancements:
- Modify relationship type conversion and resolver logic to respect the always_use_list flag