### PR TITLE
Stop the release check workflow from executing pull request code

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -9,6 +9,9 @@ on:
     - "src/strawberry_sqlalchemy_mapper/**"
     - "pyproject.toml"
 
+permissions:
+  contents: read
+
 jobs:
   get-contributor-info:
     name: Get PR info
@@ -65,10 +68,16 @@ jobs:
       change_type: ${{ steps.release-check.outputs.change_type }}
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+    - name: Checkout base repository
+      uses: actions/checkout@v4
       with:
-        ref: "refs/pull/${{ github.event.number }}/merge"
+        persist-credentials: false
+
+    - name: Get RELEASE.md from the pull request
+      run: |
+        rm -f RELEASE.md
+        git fetch --no-tags --depth=1 origin "refs/pull/${{ github.event.number }}/head"
+        git checkout FETCH_HEAD -- RELEASE.md || true
 
     - name: Release file check
       uses: ./.github/release-check-action
@@ -81,7 +90,9 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Send comment
       uses: ./.github/bot-action
       env:


### PR DESCRIPTION
## Description

The release check workflow runs on `pull_request_target`, which executes with the base
repository's secrets and token. It then checked out the pull request's own code and ran
`./.github/release-check-action` from it, so a fork could replace that action and have it execute
in a trusted context — the "pwn request" pattern.

`actions/checkout` now refuses this by default, which currently breaks the release check for every
pull request opened from a fork:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow.
```

The action only needs to read `RELEASE.md`. This changes the job to check out the base repository,
so the action itself is trusted code, and to take only `RELEASE.md` from the pull request, where
it is parsed as data:

```yaml
- name: Checkout base repository
  uses: actions/checkout@v4
  with:
    persist-credentials: false

- name: Get RELEASE.md from the pull request
  run: |
    rm -f RELEASE.md
    git fetch --no-tags --depth=1 origin "refs/pull/${{ github.event.number }}/head"
    git checkout FETCH_HEAD -- RELEASE.md || true
```

Because the fork's ref is never passed to `actions/checkout`, `allow-unsafe-pr-checkout` is not
needed.

Also in this PR:

- Added `permissions: contents: read` at the workflow level. The `send-comment` job posts through
  its own API and does not use `GITHUB_TOKEN`, so nothing needs more than read access.
- Bumped `actions/checkout` from v2 to v4 in both jobs, which clears the Node 20 deprecation
  warning.

This is kept separate from
https://github.com/strawberry-graphql/strawberry-sqlalchemy/pull/260 because `pull_request_target`
always runs the workflow from the base branch, so the fix has to land on `main` before any pull
request can benefit from it. This PR touches no path that triggers the release check, so it is not
blocked by the bug it fixes.

## Types of Changes

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [x] Enhancement/optimization
- [ ] Documentation

## Issues Fixed or Closed by This PR

* None

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything.

## Summary by Sourcery

Secure the release check workflow by running trusted base-branch code and treating pull request release metadata as data.

Bug Fixes:
- Prevent the release check workflow from executing untrusted pull request code in the trusted pull_request_target context.

Enhancements:
- Run the release check against the base repository while importing only the pull request's RELEASE.md for validation.
- Restrict the workflow's default token permissions to read-only repository contents.

CI:
- Upgrade actions/checkout to v4 in both release-check jobs.